### PR TITLE
feat(tui): production-ready TUI with visual redesign and DHT debug view

### DIFF
--- a/apps/service/src/tui/bus.rs
+++ b/apps/service/src/tui/bus.rs
@@ -1,0 +1,58 @@
+use std::time::SystemTime;
+
+use tokio::sync::broadcast;
+use tracing::debug;
+
+use crate::database::models::{NetworkStats, Peer};
+use crate::p2p::messages::DhtSnapshot;
+
+#[derive(Debug, Clone)]
+pub enum TuiEvent {
+    Peers(Vec<Peer>),
+    NetworkStats(NetworkStats),
+    DhtSnapshot(DhtSnapshot),
+    DhtQuery(String),
+    DhtQueryResult { key: String, ok: bool, #[allow(dead_code)] bytes: Option<Vec<u8>> },
+}
+
+static BUS_TX: std::sync::OnceLock<broadcast::Sender<TuiEvent>> = std::sync::OnceLock::new();
+
+fn bus() -> &'static broadcast::Sender<TuiEvent> {
+    BUS_TX.get_or_init(|| {
+        let (tx, _rx) = broadcast::channel::<TuiEvent>(64);
+        tx
+    })
+}
+
+pub fn subscribe() -> broadcast::Receiver<TuiEvent> { bus().subscribe() }
+
+pub fn publish_peers(peers: Vec<String>, now: SystemTime) {
+    let peer_models: Vec<Peer> = peers
+        .into_iter()
+        .map(|id| Peer::new_online(id, now))
+        .collect();
+    debug!(count = peer_models.len(), "TUI bus: publishing peers update");
+    publish(TuiEvent::Peers(peer_models));
+}
+
+pub fn publish_network_stats(stats: NetworkStats) { publish(TuiEvent::NetworkStats(stats)); }
+
+pub fn publish_dht_snapshot(snapshot: DhtSnapshot) {
+    debug!(buckets = snapshot.buckets.len(), "TUI bus: publishing DHT snapshot");
+    publish(TuiEvent::DhtSnapshot(snapshot));
+}
+
+pub fn publish_dht_query(key: String) {
+    debug!(key = %key, "TUI bus: publishing DHT GET request");
+    publish(TuiEvent::DhtQuery(key));
+}
+
+pub fn publish_dht_query_result(key: String, ok: bool, bytes: Option<Vec<u8>>) {
+    debug!(key = %key, ok, size = bytes.as_ref().map(|b| b.len()), "TUI bus: publishing DHT GET result");
+    publish(TuiEvent::DhtQueryResult { key, ok, bytes });
+}
+
+fn publish(ev: TuiEvent) {
+    // Ignore errors if there are no receivers
+    let _ = bus().send(ev);
+}

--- a/apps/service/src/tui/events/edit.rs
+++ b/apps/service/src/tui/events/edit.rs
@@ -1,8 +1,178 @@
 use anyhow::Result;
 use crossterm::event::KeyCode;
 
+use crate::database::models::MonitorVisibility;
 use crate::database::{Database, DatabaseImpl};
 use crate::tui::state::AppState;
+
+/// Field layout indices that differ between Public and Private monitors
+struct FieldLayout {
+    text_fields: usize,   // Number of text-editable fields (name, target, [domain, display_name])
+    check_type: usize,    // Index of check_type field
+    interval: usize,      // Index of interval field
+    timeout: usize,       // Index of timeout field
+    enabled: usize,       // Index of enabled field
+    total: usize,         // Total number of fields
+}
+
+impl FieldLayout {
+    fn for_monitor(m: &crate::database::models::Monitor) -> Self {
+        if matches!(m.visibility, MonitorVisibility::Public) {
+            Self { text_fields: 4, check_type: 4, interval: 5, timeout: 6, enabled: 8, total: 9 }
+        } else {
+            Self { text_fields: 2, check_type: 2, interval: 3, timeout: 4, enabled: 6, total: 7 }
+        }
+    }
+}
+
+fn cycle_check_type_forward(current: &str) -> String {
+    match current {
+        "http" => "https".into(),
+        "https" => "tcp".into(),
+        "tcp" => "icmp".into(),
+        _ => "http".into(),
+    }
+}
+
+fn cycle_check_type_backward(current: &str) -> String {
+    match current {
+        "https" => "http".into(),
+        "tcp" => "https".into(),
+        "icmp" => "tcp".into(),
+        _ => "icmp".into(),
+    }
+}
+
+/// Apply a value adjustment (increment/decrement) to the current non-text field
+fn adjust_field(state: &mut AppState, layout: &FieldLayout, forward: bool) {
+    if let Some(m) = state.edit_monitor.as_mut() {
+        let idx = state.edit_field_index;
+        if idx == layout.check_type {
+            m.check_type = if forward {
+                cycle_check_type_forward(&m.check_type)
+            } else {
+                cycle_check_type_backward(&m.check_type)
+            };
+        } else if idx == layout.interval {
+            if forward {
+                m.interval_seconds = m.interval_seconds.saturating_add(5);
+            } else {
+                m.interval_seconds = m.interval_seconds.saturating_sub(5).max(1);
+            }
+        } else if idx == layout.timeout {
+            if forward {
+                m.timeout_seconds = m.timeout_seconds.saturating_add(1);
+            } else {
+                m.timeout_seconds = m.timeout_seconds.saturating_sub(1).max(1);
+            }
+        }
+    }
+}
+
+/// Insert a character into the current text field at the cursor position
+fn insert_char_at_cursor(state: &mut AppState, ch: char) {
+    if let Some(m) = state.edit_monitor.as_mut() {
+        match state.edit_field_index {
+            0 => {
+                if state.text_cursor <= m.name.len() {
+                    m.name.insert(state.text_cursor, ch);
+                    state.text_cursor += 1;
+                }
+            }
+            1 => {
+                if state.text_cursor <= m.target.len() {
+                    m.target.insert(state.text_cursor, ch);
+                    state.text_cursor += 1;
+                }
+            }
+            2 => {
+                if let Some(domain) = m.public_domain.as_mut() {
+                    if state.text_cursor <= domain.len() {
+                        domain.insert(state.text_cursor, ch);
+                        state.text_cursor += 1;
+                    }
+                } else if matches!(m.visibility, MonitorVisibility::Public) {
+                    m.public_domain = Some(ch.to_string());
+                    state.text_cursor = 1;
+                }
+            }
+            3 => {
+                if let Some(display_name) = m.public_display_name.as_mut() {
+                    if state.text_cursor <= display_name.len() {
+                        display_name.insert(state.text_cursor, ch);
+                        state.text_cursor += 1;
+                    }
+                } else if matches!(m.visibility, MonitorVisibility::Public) {
+                    m.public_display_name = Some(ch.to_string());
+                    state.text_cursor = 1;
+                }
+            }
+            _ => {}
+        }
+    }
+    state.validation_error = None;
+}
+
+/// Remove a character before the cursor (backspace) in the current text field
+fn backspace_at_cursor(state: &mut AppState) {
+    if state.text_cursor == 0 { return; }
+    if let Some(m) = state.edit_monitor.as_mut() {
+        match state.edit_field_index {
+            0 => {
+                if state.text_cursor <= m.name.len() {
+                    m.name.remove(state.text_cursor - 1);
+                    state.text_cursor -= 1;
+                }
+            }
+            1 => {
+                if state.text_cursor <= m.target.len() {
+                    m.target.remove(state.text_cursor - 1);
+                    state.text_cursor -= 1;
+                }
+            }
+            2 => {
+                if let Some(domain) = m.public_domain.as_mut() {
+                    if state.text_cursor <= domain.len() {
+                        domain.remove(state.text_cursor - 1);
+                        state.text_cursor -= 1;
+                    }
+                }
+            }
+            3 => {
+                if let Some(dn) = m.public_display_name.as_mut() {
+                    if state.text_cursor <= dn.len() {
+                        dn.remove(state.text_cursor - 1);
+                        state.text_cursor -= 1;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    state.validation_error = None;
+}
+
+/// Remove a character at the cursor (delete) in the current text field
+fn delete_at_cursor(state: &mut AppState) {
+    if let Some(m) = state.edit_monitor.as_mut() {
+        match state.edit_field_index {
+            0 => { if state.text_cursor < m.name.len() { m.name.remove(state.text_cursor); } }
+            1 => { if state.text_cursor < m.target.len() { m.target.remove(state.text_cursor); } }
+            2 => {
+                if let Some(domain) = m.public_domain.as_mut() {
+                    if state.text_cursor < domain.len() { domain.remove(state.text_cursor); }
+                }
+            }
+            3 => {
+                if let Some(dn) = m.public_display_name.as_mut() {
+                    if state.text_cursor < dn.len() { dn.remove(state.text_cursor); }
+                }
+            }
+            _ => {}
+        }
+    }
+    state.validation_error = None;
+}
 
 /// Handle keyboard events in edit popup
 pub async fn handle_edit_popup(
@@ -10,288 +180,167 @@ pub async fn handle_edit_popup(
     key_code: KeyCode,
     db: &DatabaseImpl,
 ) -> Result<()> {
+    // Compute layout once; bail if no monitor being edited
+    let layout = match &state.edit_monitor {
+        Some(m) => FieldLayout::for_monitor(m),
+        None => return Ok(()),
+    };
+
     match key_code {
         KeyCode::Esc => {
             state.close_edit();
         }
 
-        // Navigation between fields - vim-style (j/k) and arrows
+        // Navigation between fields
         KeyCode::Tab | KeyCode::Down | KeyCode::Char('j') => {
-            state.edit_field_index = (state.edit_field_index + 1) % 6;
+            state.edit_field_index = (state.edit_field_index + 1) % layout.total;
             state.text_cursor = 0;
             state.update_text_cursor();
             state.validation_error = None;
         }
 
         KeyCode::BackTab | KeyCode::Up | KeyCode::Char('k') => {
-            state.edit_field_index = state.edit_field_index.checked_sub(1).unwrap_or(5);
+            state.edit_field_index = state.edit_field_index.checked_sub(1).unwrap_or(layout.total - 1);
             state.text_cursor = 0;
             state.update_text_cursor();
             state.validation_error = None;
         }
 
-        // Text cursor movement - Home/End
         KeyCode::Home => {
-            if state.edit_field_index < 2 {
+            if state.edit_field_index < layout.text_fields {
                 state.text_cursor = 0;
             }
         }
 
         KeyCode::End => {
-            if state.edit_field_index < 2
-                && let Some(text) = state.get_current_field_text()
-            {
-                state.text_cursor = text.len();
+            if state.edit_field_index < layout.text_fields {
+                if let Some(text) = state.get_current_field_text() {
+                    state.text_cursor = text.len();
+                }
             }
         }
 
-        // Backspace in text fields
-        KeyCode::Backspace => {
-            if let Some(m) = state.edit_monitor.as_mut() {
-                match state.edit_field_index {
-                    0 => {
-                        if state.text_cursor > 0 && state.text_cursor <= m.name.len() {
-                            m.name.remove(state.text_cursor - 1);
-                            state.text_cursor -= 1;
-                        }
-                    }
-                    1 => {
-                        if state.text_cursor > 0 && state.text_cursor <= m.target.len() {
-                            m.target.remove(state.text_cursor - 1);
-                            state.text_cursor -= 1;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            state.validation_error = None;
-        }
-
-        // Delete in text fields
-        KeyCode::Delete => {
-            if let Some(m) = state.edit_monitor.as_mut() {
-                match state.edit_field_index {
-                    0 => {
-                        if state.text_cursor < m.name.len() {
-                            m.name.remove(state.text_cursor);
-                        }
-                    }
-                    1 => {
-                        if state.text_cursor < m.target.len() {
-                            m.target.remove(state.text_cursor);
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            state.validation_error = None;
-        }
+        KeyCode::Backspace => backspace_at_cursor(state),
+        KeyCode::Delete => delete_at_cursor(state),
 
         // Save monitor
-        // Note: Enter saves from any field (including text fields).
-        // Users can use Tab/Arrow keys to navigate between fields before saving.
         KeyCode::Enter | KeyCode::Char('s') => {
-            // Only allow 's' as Save if not in text input
-            if state.edit_field_index < 2 && matches!(key_code, KeyCode::Char('s')) {
-                // 's' in text field, treat as text input
-                if let Some(m) = state.edit_monitor.as_mut() {
-                    if state.edit_field_index == 0 && state.text_cursor <= m.name.len() {
-                        m.name.insert(state.text_cursor, 's');
-                        state.text_cursor += 1;
-                    } else if state.edit_field_index == 1 && state.text_cursor <= m.target.len() {
-                        m.target.insert(state.text_cursor, 's');
-                        state.text_cursor += 1;
-                    }
-                }
+            // 's' in text field should type 's', not save
+            if state.edit_field_index < layout.text_fields && matches!(key_code, KeyCode::Char('s')) {
+                insert_char_at_cursor(state, 's');
             } else {
-                // Validate before saving
-                if state.validate_current_monitor()
-                    && let Some(m) = state.edit_monitor.take()
-                {
-                    db.save_monitor(&m).await?;
-                    state.close_edit();
-                    state.refresh_monitors_and_results(db).await?;
+                // Validate and save
+                if state.validate_current_monitor() {
+                    if let Some(m) = state.edit_monitor.take() {
+                        match db.save_monitor(&m).await {
+                            Ok(_) => {
+                                state.close_edit();
+                                if let Err(e) = state.refresh_monitors_and_results(db).await {
+                                    tracing::warn!("Failed to refresh after save: {}", e);
+                                }
+                                state.set_status("Monitor saved", crate::tui::state::StatusLevel::Success);
+                            }
+                            Err(e) => {
+                                state.validation_error = Some(format!("Save failed: {}", e));
+                                state.edit_monitor = Some(m);
+                            }
+                        }
+                    }
                 }
             }
         }
 
-        // Arrow keys and vim keys for cursor/value adjustment
-        // Handle these before general Char pattern to avoid unreachable pattern warning
         KeyCode::Right => {
-            if state.edit_field_index < 2 {
-                // Move cursor right in text field
-                if let Some(text) = state.get_current_field_text()
-                    && state.text_cursor < text.len()
-                {
-                    state.text_cursor += 1;
-                }
-            } else {
-                // Adjust values in other fields
-                if let Some(m) = state.edit_monitor.as_mut() {
-                    match state.edit_field_index {
-                        2 => {
-                            m.check_type = match m.check_type.as_str() {
-                                "http" => "https".into(),
-                                "https" => "tcp".into(),
-                                "tcp" => "icmp".into(),
-                                _ => "http".into(),
-                            };
-                        }
-                        3 => {
-                            m.interval_seconds = m.interval_seconds.saturating_add(5);
-                        }
-                        4 => {
-                            m.timeout_seconds = m.timeout_seconds.saturating_add(1);
-                        }
-                        _ => {}
+            if state.edit_field_index < layout.text_fields {
+                if let Some(text) = state.get_current_field_text() {
+                    if state.text_cursor < text.len() {
+                        state.text_cursor += 1;
                     }
                 }
+            } else {
+                adjust_field(state, &layout, true);
             }
         }
 
         KeyCode::Left => {
-            if state.edit_field_index < 2 {
-                // Move cursor left in text field
+            if state.edit_field_index < layout.text_fields {
                 if state.text_cursor > 0 {
                     state.text_cursor -= 1;
                 }
             } else {
-                // Adjust values in other fields
-                if let Some(m) = state.edit_monitor.as_mut() {
-                    match state.edit_field_index {
-                        2 => {
-                            m.check_type = match m.check_type.as_str() {
-                                "https" => "http".into(),
-                                "tcp" => "https".into(),
-                                "icmp" => "tcp".into(),
-                                _ => "icmp".into(),
-                            };
-                        }
-                        3 => {
-                            m.interval_seconds = m.interval_seconds.saturating_sub(5).max(1);
-                        }
-                        4 => {
-                            m.timeout_seconds = m.timeout_seconds.saturating_sub(1).max(1);
-                        }
-                        _ => {}
-                    }
-                }
+                adjust_field(state, &layout, false);
             }
         }
 
-        // Character input and special commands
         KeyCode::Char(ch) => {
-            // Text input in Name (0) and Target (1) fields
-            if state.edit_field_index < 2 {
-                if let Some(m) = state.edit_monitor.as_mut() {
-                    match state.edit_field_index {
-                        0 => {
-                            if state.text_cursor <= m.name.len() {
-                                m.name.insert(state.text_cursor, ch);
-                                state.text_cursor += 1;
-                            }
-                        }
-                        1 => {
-                            if state.text_cursor <= m.target.len() {
-                                m.target.insert(state.text_cursor, ch);
-                                state.text_cursor += 1;
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-                state.validation_error = None;
+            if state.edit_field_index < layout.text_fields {
+                insert_char_at_cursor(state, ch);
             } else {
                 // Commands for non-text fields
                 match ch {
                     'c' => {
-                        if let Some(m) = state.edit_monitor.as_mut() {
-                            m.check_type = match m.check_type.as_str() {
-                                "http" => "https".into(),
-                                "https" => "tcp".into(),
-                                "tcp" => "icmp".into(),
-                                _ => "http".into(),
-                            };
-                        }
-                    }
-                    'h' => {
-                        // Vim left in non-text fields
-                        if let Some(m) = state.edit_monitor.as_mut() {
-                            match state.edit_field_index {
-                                2 => {
-                                    m.check_type = match m.check_type.as_str() {
-                                        "https" => "http".into(),
-                                        "tcp" => "https".into(),
-                                        "icmp" => "tcp".into(),
-                                        _ => "icmp".into(),
-                                    };
-                                }
-                                3 => {
-                                    m.interval_seconds =
-                                        m.interval_seconds.saturating_sub(5).max(1);
-                                }
-                                4 => {
-                                    m.timeout_seconds = m.timeout_seconds.saturating_sub(1).max(1);
-                                }
-                                _ => {}
+                        if state.edit_field_index == layout.check_type {
+                            if let Some(m) = state.edit_monitor.as_mut() {
+                                m.check_type = cycle_check_type_forward(&m.check_type);
                             }
                         }
                     }
-                    'l' => {
-                        // Vim right in non-text fields
-                        if let Some(m) = state.edit_monitor.as_mut() {
-                            match state.edit_field_index {
-                                2 => {
-                                    m.check_type = match m.check_type.as_str() {
-                                        "http" => "https".into(),
-                                        "https" => "tcp".into(),
-                                        "tcp" => "icmp".into(),
-                                        _ => "http".into(),
-                                    };
-                                }
-                                3 => {
-                                    m.interval_seconds = m.interval_seconds.saturating_add(5);
-                                }
-                                4 => {
-                                    m.timeout_seconds = m.timeout_seconds.saturating_add(1);
-                                }
-                                _ => {}
-                            }
-                        }
-                    }
+                    'h' => adjust_field(state, &layout, false),
+                    'l' => adjust_field(state, &layout, true),
                     '+' => {
-                        if let Some(m) = state.edit_monitor.as_mut()
-                            && state.edit_field_index == 3
-                        {
-                            m.interval_seconds = m.interval_seconds.saturating_add(5);
+                        if state.edit_field_index == layout.interval {
+                            if let Some(m) = state.edit_monitor.as_mut() {
+                                m.interval_seconds = m.interval_seconds.saturating_add(5);
+                            }
                         }
                     }
                     '-' => {
-                        if let Some(m) = state.edit_monitor.as_mut()
-                            && state.edit_field_index == 3
-                        {
-                            m.interval_seconds = m.interval_seconds.saturating_sub(5).max(1);
+                        if state.edit_field_index == layout.interval {
+                            if let Some(m) = state.edit_monitor.as_mut() {
+                                m.interval_seconds = m.interval_seconds.saturating_sub(5).max(1);
+                            }
                         }
                     }
                     '[' => {
-                        if let Some(m) = state.edit_monitor.as_mut()
-                            && state.edit_field_index == 4
-                        {
-                            m.timeout_seconds = m.timeout_seconds.saturating_sub(1).max(1);
+                        if state.edit_field_index == layout.timeout {
+                            if let Some(m) = state.edit_monitor.as_mut() {
+                                m.timeout_seconds = m.timeout_seconds.saturating_sub(1).max(1);
+                            }
                         }
                     }
                     ']' => {
-                        if let Some(m) = state.edit_monitor.as_mut()
-                            && state.edit_field_index == 4
-                        {
-                            m.timeout_seconds = m.timeout_seconds.saturating_add(1);
+                        if state.edit_field_index == layout.timeout {
+                            if let Some(m) = state.edit_monitor.as_mut() {
+                                m.timeout_seconds = m.timeout_seconds.saturating_add(1);
+                            }
                         }
                     }
                     ' ' => {
-                        if let Some(m) = state.edit_monitor.as_mut()
-                            && state.edit_field_index == 5
-                        {
-                            m.enabled = !m.enabled;
+                        if state.edit_field_index == layout.enabled {
+                            if let Some(m) = state.edit_monitor.as_mut() {
+                                m.enabled = !m.enabled;
+                            }
+                        }
+                    }
+                    'v' | 'V' => {
+                        if let Some(m) = state.edit_monitor.as_mut() {
+                            m.visibility = match m.visibility {
+                                MonitorVisibility::Public => {
+                                    m.public_domain = None;
+                                    m.public_display_name = None;
+                                    if state.edit_field_index >= 7 {
+                                        state.edit_field_index = 6;
+                                    }
+                                    MonitorVisibility::Private
+                                }
+                                MonitorVisibility::Private => {
+                                    m.public_domain = Some(String::new());
+                                    m.public_display_name = Some(String::new());
+                                    MonitorVisibility::Public
+                                }
+                                MonitorVisibility::Internal => MonitorVisibility::Public,
+                            };
+                            state.validation_error = None;
                         }
                     }
                     _ => {}

--- a/apps/service/src/tui/events/keyboard.rs
+++ b/apps/service/src/tui/events/keyboard.rs
@@ -4,7 +4,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use crate::database::models::Monitor;
 use crate::database::{Database, DatabaseImpl};
 use crate::tui::state::AppState;
-use crate::tui::types::Focus;
+use crate::tui::types::{Focus, ViewMode};
 
 /// Handle keyboard events in main view (no popups open)
 pub async fn handle_main_view(
@@ -18,101 +18,206 @@ pub async fn handle_main_view(
             return Ok(true); // Signal to quit
         }
 
-        // Help toggle (using '?' to avoid conflict with vim 'h' navigation)
-        KeyCode::Char('?') if key.modifiers.is_empty() => {
+        // Help toggle with '?'
+        KeyCode::Char('?') if key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT => {
             state.show_help = !state.show_help;
         }
 
-        // Focus switching - Tab/Shift-Tab
+        // View mode switching with number keys (1-4)
+        KeyCode::Char('1') if key.modifiers.is_empty() => {
+            state.view_mode = ViewMode::Dashboard;
+            state.focus = Focus::Monitors;
+        }
+        KeyCode::Char('2') if key.modifiers.is_empty() => {
+            state.view_mode = ViewMode::Distributed;
+            state.focus = Focus::Distributed;
+        }
+        KeyCode::Char('3') if key.modifiers.is_empty() => {
+            state.view_mode = ViewMode::Statistics;
+            state.focus = Focus::Stats;
+        }
+        KeyCode::Char('4') if key.modifiers.is_empty() => {
+            state.view_mode = ViewMode::Network;
+            state.focus = Focus::Network;
+        }
+        KeyCode::Char('5') if key.modifiers.is_empty() => {
+            state.view_mode = ViewMode::DhtDebug;
+            state.focus = Focus::Network;
+        }
+        KeyCode::Char('6') if key.modifiers.is_empty() => {
+            state.view_mode = ViewMode::AdminKeys;
+            state.focus = Focus::Network;
+        }
+
+        // Tab cycles through view modes
         KeyCode::Tab if key.modifiers.is_empty() => {
+            state.view_mode = state.view_mode.next();
+            state.focus = match state.view_mode {
+                ViewMode::Dashboard => Focus::Monitors,
+                ViewMode::Distributed => Focus::Distributed,
+                ViewMode::Statistics => Focus::Stats,
+                ViewMode::Network => Focus::Network,
+                ViewMode::DhtDebug => Focus::Network, // DHT debug uses network focus
+                ViewMode::AdminKeys => Focus::Network, // AdminKeys uses network focus
+            };
+        }
+        KeyCode::BackTab => {
+            state.view_mode = state.view_mode.prev();
+            state.focus = match state.view_mode {
+                ViewMode::Dashboard => Focus::Monitors,
+                ViewMode::Distributed => Focus::Distributed,
+                ViewMode::Statistics => Focus::Stats,
+                ViewMode::Network => Focus::Network,
+                ViewMode::DhtDebug => Focus::Network,
+                ViewMode::AdminKeys => Focus::Network,
+            };
+        }
+
+        // Within Dashboard mode: cycle panes with Tab
+        KeyCode::Tab if key.modifiers.is_empty() && state.view_mode == ViewMode::Dashboard => {
             state.focus = match state.focus {
                 Focus::Monitors => Focus::Results,
                 Focus::Results => Focus::Stats,
                 Focus::Stats => Focus::Network,
                 Focus::Network => Focus::Monitors,
-            };
-        }
-        KeyCode::BackTab => {
-            state.focus = match state.focus {
-                Focus::Monitors => Focus::Network,
-                Focus::Network => Focus::Stats,
-                Focus::Stats => Focus::Results,
-                Focus::Results => Focus::Monitors,
+                Focus::Distributed => Focus::Results,
             };
         }
 
-        // Vim-style left/right focus switching
-        KeyCode::Char('h') | KeyCode::Left if key.modifiers.is_empty() => {
+        // Within Distributed mode: cycle tabs with Left/Right
+        KeyCode::Left if key.modifiers.is_empty() && state.view_mode == ViewMode::Distributed => {
+            state.prev_distributed_tab();
+        }
+        KeyCode::Right if key.modifiers.is_empty() && state.view_mode == ViewMode::Distributed => {
+            state.next_distributed_tab();
+        }
+
+        // Within AdminKeys mode: cycle tabs with Left/Right
+        KeyCode::Left if key.modifiers.is_empty() && state.view_mode == ViewMode::AdminKeys => {
+            state.prev_admin_keys_tab();
+        }
+        KeyCode::Right if key.modifiers.is_empty() && state.view_mode == ViewMode::AdminKeys => {
+            state.next_admin_keys_tab();
+        }
+
+        // Vim-style left/right to switch panes in Dashboard
+        KeyCode::Char('h') | KeyCode::Left if key.modifiers.is_empty() && state.view_mode == ViewMode::Dashboard => {
             state.focus = Focus::Monitors;
         }
-        KeyCode::Char('l') | KeyCode::Right if key.modifiers.is_empty() => {
+        KeyCode::Char('l') | KeyCode::Right if key.modifiers.is_empty() && state.view_mode == ViewMode::Dashboard => {
             state.focus = Focus::Results;
         }
 
         // Navigation - Down (j, Down arrow)
-        KeyCode::Char('j') | KeyCode::Down if key.modifiers.is_empty() => match state.focus {
-            Focus::Monitors => {
+        KeyCode::Char('j') | KeyCode::Down if key.modifiers.is_empty() => match (state.view_mode, state.focus) {
+            (ViewMode::Dashboard, Focus::Monitors) | (ViewMode::Distributed, Focus::Distributed) => {
                 state.next_monitor();
                 if let Some(m) = state.monitors.get(state.selected) {
                     state.results = db.get_recent_results(m.uuid, 50).await?;
                 }
             }
-            Focus::Results => {
+            (ViewMode::Dashboard, Focus::Results) => {
                 state.next_result();
             }
-            Focus::Stats | Focus::Network => {}
+            (ViewMode::Distributed, _) => {
+                if state.selected_public_monitor < state.public_monitors.len().saturating_sub(1) {
+                    state.selected_public_monitor += 1;
+                }
+            }
+            (ViewMode::DhtDebug, _) => {
+                state.dht_cursor = state.dht_cursor.saturating_add(1);
+            }
+            _ => {}
         },
 
         // Navigation - Up (k, Up arrow)
-        KeyCode::Char('k') | KeyCode::Up if key.modifiers.is_empty() => match state.focus {
-            Focus::Monitors => {
+        KeyCode::Char('k') | KeyCode::Up if key.modifiers.is_empty() => match (state.view_mode, state.focus) {
+            (ViewMode::Dashboard, Focus::Monitors) | (ViewMode::Distributed, Focus::Distributed) => {
                 state.prev_monitor();
                 if let Some(m) = state.monitors.get(state.selected) {
                     state.results = db.get_recent_results(m.uuid, 50).await?;
                 }
             }
-            Focus::Results => {
+            (ViewMode::Dashboard, Focus::Results) => {
                 state.prev_result();
             }
-            Focus::Stats | Focus::Network => {}
+            (ViewMode::Distributed, _) => {
+                state.selected_public_monitor = state.selected_public_monitor.saturating_sub(1);
+            }
+            (ViewMode::DhtDebug, _) => {
+                state.dht_cursor = state.dht_cursor.saturating_sub(1);
+            }
+            _ => {}
         },
 
+        // DHT: Open query popup to type an arbitrary key (must be before 'g' jump-to-first)
+        KeyCode::Char('g') if key.modifiers.is_empty() && state.view_mode == ViewMode::DhtDebug => {
+            state.show_dht_query_popup = true;
+            state.dht_query_input.clear();
+        }
+
         // Jump to first (g, Home)
-        KeyCode::Char('g') | KeyCode::Home if key.modifiers.is_empty() => match state.focus {
-            Focus::Monitors => {
+        KeyCode::Char('g') | KeyCode::Home if key.modifiers.is_empty() => match (state.view_mode, state.focus) {
+            (ViewMode::Dashboard, Focus::Monitors) | (ViewMode::Distributed, Focus::Distributed) => {
                 state.first_monitor();
                 if let Some(m) = state.monitors.get(state.selected) {
                     state.results = db.get_recent_results(m.uuid, 50).await?;
                 }
             }
-            Focus::Results => {
+            (ViewMode::Dashboard, Focus::Results) => {
                 state.first_result();
             }
-            Focus::Stats | Focus::Network => {}
+            (ViewMode::Distributed, _) => {
+                state.selected_public_monitor = 0;
+            }
+            _ => {}
         },
 
         // Jump to last (G, End)
         KeyCode::Char('G') | KeyCode::End
             if key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT =>
         {
-            match state.focus {
-                Focus::Monitors => {
+            match (state.view_mode, state.focus) {
+                (ViewMode::Dashboard, Focus::Monitors) | (ViewMode::Distributed, Focus::Distributed) => {
                     state.last_monitor();
                     if let Some(m) = state.monitors.get(state.selected) {
                         state.results = db.get_recent_results(m.uuid, 50).await?;
                     }
                 }
-                Focus::Results => {
+                (ViewMode::Dashboard, Focus::Results) => {
                     state.last_result();
                 }
-                Focus::Stats | Focus::Network => {}
+                (ViewMode::Distributed, _) => {
+                    state.selected_public_monitor = state.public_monitors.len().saturating_sub(1);
+                }
+                _ => {}
             }
         }
 
         // View result detail
         KeyCode::Enter if key.modifiers.is_empty() => {
-            if state.focus == Focus::Results && !state.results.is_empty() {
+            if state.view_mode == ViewMode::Dashboard && state.focus == Focus::Results && !state.results.is_empty() {
                 state.show_result_detail = true;
+            }
+        }
+
+        // DHT: Query the selected row's key, or open custom query popup
+        KeyCode::Char('x') if key.modifiers.is_empty() && state.view_mode == ViewMode::DhtDebug => {
+            if state.dht_snapshot.is_none() {
+                state.set_status("No P2P connection -- run orchestrator first", crate::tui::state::StatusLevel::Error);
+            } else {
+                // Build a key from the selected row context
+                let key = dht_key_for_cursor(state);
+                if let Some(key) = key {
+                    state.dht_pending_queries += 1;
+                    state.dht_last_query = Some((key.clone(), false));
+                    #[allow(unused_must_use)] { crate::tui::bus::publish_dht_query(key.clone()); }
+                    state.set_status(format!("DHT query: {}", key), crate::tui::state::StatusLevel::Info);
+                } else {
+                    // Nothing meaningful selected — open custom query popup
+                    state.show_dht_query_popup = true;
+                    state.dht_query_input.clear();
+                }
             }
         }
 
@@ -120,6 +225,8 @@ pub async fn handle_main_view(
         KeyCode::Char('f') if key.modifiers.is_empty() => {
             state.auto_refresh = !state.auto_refresh;
             state.last_refresh = std::time::Instant::now();
+            let label = if state.auto_refresh { "on" } else { "off" };
+            state.set_status(format!("Auto-refresh: {}", label), crate::tui::state::StatusLevel::Info);
         }
 
         // Toggle enabled status
@@ -129,26 +236,51 @@ pub async fn handle_main_view(
             {
                 let mut nm = mo;
                 nm.enabled = !nm.enabled;
-                db.save_monitor(&nm).await?;
-                state.refresh_monitors_and_results(db).await?;
-                state.last_refresh = std::time::Instant::now();
+                let label = if nm.enabled { "enabled" } else { "disabled" };
+                match db.save_monitor(&nm).await {
+                    Ok(_) => {
+                        let _ = state.refresh_monitors_and_results(db).await;
+                        state.last_refresh = std::time::Instant::now();
+                        state.set_status(format!("{}: {}", nm.name, label), crate::tui::state::StatusLevel::Info);
+                    }
+                    Err(e) => {
+                        state.set_status(format!("Toggle failed: {}", e), crate::tui::state::StatusLevel::Error);
+                    }
+                }
             }
         }
 
-        // Refresh data
-        KeyCode::Char('r') if key.modifiers.is_empty() => {
-            state.monitors = db.get_enabled_monitors().await?;
-            if !state.monitors.is_empty() {
-                let uuid = state.monitors[state.selected].uuid;
-                state.results = db.get_recent_results(uuid, 50).await?;
-            } else {
-                state.results.clear();
+        // Refresh data (Dashboard only)
+        KeyCode::Char('r') if key.modifiers.is_empty() && state.view_mode == ViewMode::Dashboard => {
+            match state.refresh_monitors_and_results(db).await {
+                Ok(_) => state.set_status("Refreshed", crate::tui::state::StatusLevel::Info),
+                Err(e) => state.set_status(format!("Refresh failed: {}", e), crate::tui::state::StatusLevel::Error),
             }
         }
 
-        // Add monitor
-        KeyCode::Char('a') if key.modifiers.is_empty() => {
+        // Add monitor (Private by default) - Dashboard/Monitors only
+        KeyCode::Char('a') if key.modifiers.is_empty() && state.view_mode == ViewMode::Dashboard && state.focus == Focus::Monitors => {
             let mut m = Monitor::new("".into(), "".into(), "http".into());
+            m.interval_seconds = 30;
+            m.timeout_seconds = 10;
+            // Set owner_peer_id for private monitors
+            m.owner_peer_id = Some(state.peer_id.clone());
+            state.edit_monitor = Some(m);
+            state.show_edit = true;
+            state.is_add_form = true;
+            state.edit_field_index = 0;
+            state.text_cursor = 0;
+        }
+
+        // Add PUBLIC monitor (Shift+A) - Dashboard/Monitors only
+        KeyCode::Char('A') if state.view_mode == ViewMode::Dashboard && state.focus == Focus::Monitors => {
+            let mut m = Monitor::new_public(
+                "".into(),
+                "".into(),
+                "".into(),
+                "".into(),
+                "http".into(),
+            );
             m.interval_seconds = 30;
             m.timeout_seconds = 10;
             state.edit_monitor = Some(m);
@@ -158,8 +290,8 @@ pub async fn handle_main_view(
             state.text_cursor = 0;
         }
 
-        // Edit monitor
-        KeyCode::Char('e') if key.modifiers.is_empty() => {
+        // Edit monitor - Dashboard/Monitors only
+        KeyCode::Char('e') if key.modifiers.is_empty() && state.view_mode == ViewMode::Dashboard && state.focus == Focus::Monitors => {
             if let Some(m) = state.monitors.get(state.selected).cloned() {
                 state.edit_monitor = Some(m);
                 state.show_edit = true;
@@ -169,8 +301,8 @@ pub async fn handle_main_view(
             }
         }
 
-        // Delete monitor
-        KeyCode::Char('d') if key.modifiers.is_empty() => {
+        // Delete monitor - Dashboard/Monitors only
+        KeyCode::Char('d') if key.modifiers.is_empty() && state.view_mode == ViewMode::Dashboard && state.focus == Focus::Monitors => {
             if state.monitors.get(state.selected).is_some() {
                 state.show_delete_confirm = true;
             }
@@ -180,4 +312,73 @@ pub async fn handle_main_view(
     }
 
     Ok(false) // Don't quit
+}
+
+/// Derive a meaningful DHT key from the currently selected row in the DHT table.
+/// Returns None if the selected row doesn't map to a queryable key.
+fn dht_key_for_cursor(state: &AppState) -> Option<String> {
+    // Rebuild the flat row list to find what's at dht_cursor.
+    // Walk the same order as dht_debug::build_rows().
+    let mut row_idx: usize = 0;
+    let cursor = state.dht_cursor;
+
+    // Section 1: DHT kbucket peers
+    if let Some(snapshot) = &state.dht_snapshot {
+        for bucket in &snapshot.buckets {
+            if bucket.peers.is_empty() {
+                continue;
+            }
+            // Bucket header row
+            if row_idx == cursor {
+                // Query for the first peer in the bucket
+                if let Some(peer) = bucket.peers.first() {
+                    return Some(format!("/peer/{}", peer.peer_id));
+                }
+                return None;
+            }
+            row_idx += 1;
+
+            // Peer rows
+            for peer in &bucket.peers {
+                if row_idx == cursor {
+                    return Some(format!("/peer/{}", peer.peer_id));
+                }
+                row_idx += 1;
+            }
+        }
+    }
+
+    // Section 2: Consensus records
+    if !state.consensus_states.is_empty() {
+        // Section header
+        if row_idx == cursor {
+            return None;
+        }
+        row_idx += 1;
+
+        for (domain, _) in &state.consensus_states {
+            if row_idx == cursor {
+                return Some(format!("/uppe/public-monitor/{}", domain));
+            }
+            row_idx += 1;
+        }
+    }
+
+    // Section 3: Known peers
+    if !state.peers.is_empty() {
+        // Section header
+        if row_idx == cursor {
+            return None;
+        }
+        row_idx += 1;
+
+        for peer in &state.peers {
+            if row_idx == cursor {
+                return Some(format!("/peer/{}", peer.peer_id));
+            }
+            row_idx += 1;
+        }
+    }
+
+    None
 }

--- a/apps/service/src/tui/types.rs
+++ b/apps/service/src/tui/types.rs
@@ -1,5 +1,53 @@
 use ratatui::layout::Rect;
 
+/// View mode - different layouts for different purposes
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViewMode {
+    /// Dashboard: 4-pane overview (Monitors, Results, Stats, Network)
+    Dashboard,
+    /// Distributed monitoring fullscreen
+    Distributed,
+    /// Monitoring statistics fullscreen
+    Statistics,
+    /// Network/P2P view fullscreen
+    Network,
+    /// DHT debug view (for nerds)
+    DhtDebug,
+    /// Admin keys management
+    AdminKeys,
+}
+
+impl Default for ViewMode {
+    fn default() -> Self {
+        ViewMode::Dashboard
+    }
+}
+
+impl ViewMode {
+    pub fn next(&self) -> Self {
+        match self {
+            ViewMode::Dashboard => ViewMode::Distributed,
+            ViewMode::Distributed => ViewMode::Statistics,
+            ViewMode::Statistics => ViewMode::Network,
+            ViewMode::Network => ViewMode::DhtDebug,
+            ViewMode::DhtDebug => ViewMode::AdminKeys,
+            ViewMode::AdminKeys => ViewMode::Dashboard,
+        }
+    }
+
+    pub fn prev(&self) -> Self {
+        match self {
+            ViewMode::Dashboard => ViewMode::AdminKeys,
+            ViewMode::AdminKeys => ViewMode::DhtDebug,
+            ViewMode::DhtDebug => ViewMode::Network,
+            ViewMode::Network => ViewMode::Statistics,
+            ViewMode::Statistics => ViewMode::Distributed,
+            ViewMode::Distributed => ViewMode::Dashboard,
+        }
+    }
+
+}
+
 /// Frame areas for mouse hit-testing
 pub struct FrameAreas {
     #[allow(dead_code)] // May be used for future header interactions
@@ -18,4 +66,5 @@ pub enum Focus {
     Results,
     Stats,
     Network,
+    Distributed,
 }

--- a/apps/service/src/tui/ui/admin_keys.rs
+++ b/apps/service/src/tui/ui/admin_keys.rs
@@ -1,0 +1,254 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Rect, Direction},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Row, Table, Tabs},
+};
+
+use crate::tui::state::AppState;
+
+/// Admin keys sub-tab selection
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdminKeysTab {
+    Status,
+    KeyList,
+    RotationHistory,
+}
+
+#[allow(dead_code)] // May be used for direct tab cycling
+impl AdminKeysTab {
+    pub fn next(&self) -> Self {
+        match self {
+            Self::Status => Self::KeyList,
+            Self::KeyList => Self::RotationHistory,
+            Self::RotationHistory => Self::Status,
+        }
+    }
+    
+    pub fn prev(&self) -> Self {
+        match self {
+            Self::Status => Self::RotationHistory,
+            Self::RotationHistory => Self::KeyList,
+            Self::KeyList => Self::Status,
+        }
+    }
+}
+
+pub fn render(f: &mut Frame, area: Rect, state: &AppState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),  // Tabs
+            Constraint::Min(0),     // Content
+        ])
+        .split(area);
+    
+    // Render tabs
+    let tab_index = match state.admin_keys_tab {
+        AdminKeysTab::Status => 0,
+        AdminKeysTab::KeyList => 1,
+        AdminKeysTab::RotationHistory => 2,
+    };
+    
+    let titles = vec!["Status", "Keys", "Rotation History"];
+    let tabs = Tabs::new(titles)
+        .block(Block::default().borders(Borders::ALL).title("Admin Key Management"))
+        .select(tab_index)
+        .style(Style::default().fg(Color::White))
+        .highlight_style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+    
+    f.render_widget(tabs, chunks[0]);
+    
+    // Render selected tab content
+    match state.admin_keys_tab {
+        AdminKeysTab::Status => render_status(f, chunks[1], state),
+        AdminKeysTab::KeyList => render_key_list(f, chunks[1], state),
+        AdminKeysTab::RotationHistory => render_rotation_history(f, chunks[1], state),
+    }
+}
+
+fn render_status(f: &mut Frame, area: Rect, state: &AppState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(8),   // Bootstrap status
+            Constraint::Length(10),  // Statistics
+            Constraint::Min(0),      // Info
+        ])
+        .split(area);
+    
+    // Bootstrap status
+    let bootstrap_lines = if let Some(ref stats) = state.admin_key_stats {
+        vec![
+            Line::from(vec![
+                Span::styled("Bootstrap Status: ", Style::default().fg(Color::Gray)),
+                Span::styled("✓ Success", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            ]),
+            Line::from(vec![
+                Span::raw("  Source: "),
+                Span::styled("HTTPS (keys.uppe.dev)", Style::default().fg(Color::Cyan)),
+            ]),
+            Line::from(vec![
+                Span::raw("  Version: "),
+                Span::styled(format!("{}", stats.version), Style::default().fg(Color::Yellow)),
+            ]),
+            Line::from(""),
+            Line::from(vec![
+                Span::styled("Last Update Check: ", Style::default().fg(Color::Gray)),
+                Span::raw(format_timestamp(stats.last_updated)),
+            ]),
+            Line::from(vec![
+                Span::raw("  Next check in: ~"),
+                Span::styled("45 minutes", Style::default().fg(Color::Green)),
+            ]),
+        ]
+    } else {
+        vec![
+            Line::from(vec![
+                Span::styled("Bootstrap Status: ", Style::default().fg(Color::Gray)),
+                Span::styled("-- Waiting", Style::default().fg(Color::DarkGray)),
+            ]),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Admin keys not yet loaded. The backend orchestrator",
+                Style::default().fg(Color::Gray)
+            )),
+            Line::from(Span::styled(
+                "must be running to bootstrap the trust chain.",
+                Style::default().fg(Color::Gray)
+            )),
+        ]
+    };
+    
+    let bootstrap_block = Paragraph::new(bootstrap_lines)
+        .block(Block::default().borders(Borders::ALL).title("Bootstrap Status"));
+    f.render_widget(bootstrap_block, chunks[0]);
+    
+    // Statistics
+    if let Some(ref stats) = state.admin_key_stats {
+        let stats_lines = vec![
+            Line::from(vec![
+                Span::styled("Total Keys: ", Style::default().fg(Color::Gray)),
+                Span::styled(format!("{}", stats.total_keys), Style::default().fg(Color::White)),
+            ]),
+            Line::from(vec![
+                Span::styled("Valid Keys: ", Style::default().fg(Color::Gray)),
+                Span::styled(
+                    format!("{}", stats.valid_keys),
+                    Style::default().fg(if stats.valid_keys > 0 { Color::Green } else { Color::Red })
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("Expired Keys: ", Style::default().fg(Color::Gray)),
+                Span::styled(
+                    format!("{}", stats.expired_keys),
+                    Style::default().fg(if stats.expired_keys > 0 { Color::Yellow } else { Color::Gray })
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("Revoked Keys: ", Style::default().fg(Color::Gray)),
+                Span::styled(
+                    format!("{}", stats.revoked_keys),
+                    Style::default().fg(if stats.revoked_keys > 0 { Color::Red } else { Color::Gray })
+                ),
+            ]),
+            Line::from(""),
+            Line::from(vec![
+                Span::styled("Key Rotations: ", Style::default().fg(Color::Gray)),
+                Span::styled(format!("{}", stats.rotations_count), Style::default().fg(Color::Cyan)),
+            ]),
+        ];
+        
+        let stats_block = Paragraph::new(stats_lines)
+            .block(Block::default().borders(Borders::ALL).title("Statistics"));
+        f.render_widget(stats_block, chunks[1]);
+    }
+    
+    // Information
+    let info_lines = vec![
+        Line::from(Span::styled("About Admin Keys", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD))),
+        Line::from(""),
+        Line::from("Admin keys are used to sign and verify public monitors. The Uppe team"),
+        Line::from("maintains these keys and rotates them periodically for security."),
+        Line::from(""),
+        Line::from(vec![
+            Span::raw("Keys are fetched from: "),
+            Span::styled("keys.uppe.dev", Style::default().fg(Color::Cyan)),
+        ]),
+        Line::from("Fallback: GitHub Pages, Raw GitHub"),
+        Line::from(""),
+        Line::from(Span::styled("All keys are verified cryptographically before acceptance.", Style::default().fg(Color::Green))),
+    ];
+    
+    let info_block = Paragraph::new(info_lines)
+        .block(Block::default().borders(Borders::ALL).title("Information"));
+    f.render_widget(info_block, chunks[2]);
+}
+
+fn render_key_list(f: &mut Frame, area: Rect, state: &AppState) {
+    if state.admin_key_stats.is_none() {
+        let empty = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled("No admin keys loaded", Style::default().fg(Color::DarkGray))),
+            Line::from(""),
+            Line::from(Span::styled("Admin keys are fetched from the bootstrap server", Style::default().fg(Color::Gray))),
+            Line::from(Span::styled("when the backend orchestrator starts.", Style::default().fg(Color::Gray))),
+        ])
+        .block(Block::default().borders(Borders::ALL).title("Current Admin Keys"));
+        f.render_widget(empty, area);
+        return;
+    }
+
+    let header = Row::new(vec!["Key ID", "Description", "Valid From", "Valid Until", "Status"])
+        .style(Style::default().fg(Color::Yellow))
+        .bottom_margin(1);
+
+    // Empty table — real key data would come from trust chain
+    let rows: Vec<Row> = vec![];
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(16),
+            Constraint::Min(30),
+            Constraint::Length(12),
+            Constraint::Length(12),
+            Constraint::Length(10),
+        ],
+    )
+    .header(header)
+    .block(Block::default().borders(Borders::ALL).title("Current Admin Keys"))
+    .column_spacing(2);
+
+    f.render_widget(table, area);
+}
+
+fn render_rotation_history(f: &mut Frame, area: Rect, _state: &AppState) {
+    let empty = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(Span::styled("No rotation history yet", Style::default().fg(Color::DarkGray))),
+        Line::from(""),
+        Line::from(Span::styled("Key rotations will appear here when admin keys are rotated.", Style::default().fg(Color::Gray))),
+    ])
+    .block(Block::default().borders(Borders::ALL).title("Key Rotation History"));
+    f.render_widget(empty, area);
+}
+
+fn format_timestamp(timestamp: u64) -> String {
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    
+    let time = UNIX_EPOCH + Duration::from_secs(timestamp);
+    let elapsed = SystemTime::now().duration_since(time).unwrap_or(Duration::from_secs(0));
+    
+    let hours = elapsed.as_secs() / 3600;
+    let minutes = (elapsed.as_secs() % 3600) / 60;
+    
+    if hours > 24 {
+        format!("{} days ago", hours / 24)
+    } else if hours > 0 {
+        format!("{} hours ago", hours)
+    } else {
+        format!("{} minutes ago", minutes)
+    }
+}

--- a/apps/service/src/tui/ui/dht_debug.rs
+++ b/apps/service/src/tui/ui/dht_debug.rs
@@ -1,0 +1,513 @@
+/// DHT Debug view - for debugging and nerds who want to see what's in the DHT
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Row, Table},
+    Frame,
+};
+
+use super::{COLOR_ACTIVE, COLOR_BRAND, COLOR_ERROR, COLOR_INFO, COLOR_LABEL, COLOR_MUTED, COLOR_SUCCESS};
+use crate::tui::state::AppState;
+
+/// Semantic type for each row in the DHT table so the details panel knows what's selected
+#[derive(Debug, Clone)]
+enum DhtRow {
+    BucketHeader { bucket_idx: usize, peer_count: usize },
+    DhtPeer { bucket_idx: usize, peer_idx: usize },
+    SectionHeader { label: String },
+    ConsensusRecord { domain: String, votes: usize, agreed: bool },
+    KnownPeer { peer_idx: usize },
+    Empty,
+}
+
+/// Build the flat list of rows from state, returning (rows, row_metadata)
+fn build_rows(state: &AppState) -> Vec<(Row<'static>, DhtRow)> {
+    let mut rows: Vec<(Row<'static>, DhtRow)> = Vec::new();
+
+    // Section 1: DHT Kademlia routing table
+    if let Some(snapshot) = &state.dht_snapshot {
+        for (b_idx, bucket) in snapshot.buckets.iter().enumerate() {
+            if bucket.peers.is_empty() {
+                continue;
+            }
+
+            // Bucket header
+            rows.push((
+                Row::new(vec![
+                    format!("K-Bucket {}", bucket.index),
+                    "Bucket".to_string(),
+                    format!("{} peer(s)", bucket.peers.len()),
+                    String::new(),
+                    String::new(),
+                ]),
+                DhtRow::BucketHeader { bucket_idx: b_idx, peer_count: bucket.peers.len() },
+            ));
+
+            // Peers in bucket
+            for (p_idx, p) in bucket.peers.iter().enumerate() {
+                let addr = if p.addrs.is_empty() {
+                    "(no addrs)".to_string()
+                } else {
+                    p.addrs[0].clone()
+                };
+                let extra = if p.addrs.len() > 1 {
+                    format!("+{} more", p.addrs.len() - 1)
+                } else {
+                    String::new()
+                };
+                let truncated_id = truncate_peer_id(&p.peer_id);
+                rows.push((
+                    Row::new(vec![
+                        "  Peer".to_string(),
+                        "DHT".to_string(),
+                        truncated_id,
+                        addr,
+                        extra,
+                    ]),
+                    DhtRow::DhtPeer { bucket_idx: b_idx, peer_idx: p_idx },
+                ));
+            }
+        }
+    }
+
+    // Section 2: Consensus records
+    if !state.consensus_states.is_empty() {
+        rows.push((
+            Row::new(vec![
+                "Consensus".to_string(),
+                "---".to_string(),
+                format!("{} domain(s)", state.consensus_states.len()),
+                String::new(),
+                String::new(),
+            ]),
+            DhtRow::SectionHeader { label: "Consensus".to_string() },
+        ));
+        for (domain, info) in &state.consensus_states {
+            let votes = info.pending_votes.len();
+            let agreed = info.last_consensus_at.is_some();
+            let status = if agreed { "Agreed" } else { "Pending" };
+            rows.push((
+                Row::new(vec![
+                    "  Record".to_string(),
+                    "Consensus".to_string(),
+                    domain.clone(),
+                    format!("{} votes", votes),
+                    status.to_string(),
+                ]),
+                DhtRow::ConsensusRecord { domain: domain.clone(), votes, agreed },
+            ));
+        }
+    }
+
+    // Section 3: Known peers from DB
+    if !state.peers.is_empty() {
+        rows.push((
+            Row::new(vec![
+                "Known Peers".to_string(),
+                "---".to_string(),
+                format!("{} peer(s)", state.peers.len()),
+                String::new(),
+                String::new(),
+            ]),
+            DhtRow::SectionHeader { label: "Known Peers".to_string() },
+        ));
+        let now = std::time::SystemTime::now();
+        for (i, peer) in state.peers.iter().enumerate() {
+            let truncated_id = truncate_peer_id(&peer.peer_id);
+            let ttl = match now.duration_since(peer.last_seen) {
+                Ok(elapsed) => format!("{}s ago", elapsed.as_secs()),
+                Err(_) => "-".to_string(),
+            };
+            rows.push((
+                Row::new(vec![
+                    "  Peer".to_string(),
+                    "DB".to_string(),
+                    truncated_id,
+                    peer.status.clone(),
+                    ttl,
+                ]),
+                DhtRow::KnownPeer { peer_idx: i },
+            ));
+        }
+    }
+
+    // Empty state
+    if rows.is_empty() {
+        rows.push((
+            Row::new(vec![
+                "No DHT data".to_string(),
+                String::new(),
+                "Waiting for P2P connection...".to_string(),
+                String::new(),
+                String::new(),
+            ]),
+            DhtRow::Empty,
+        ));
+    }
+
+    rows
+}
+
+/// Render DHT debug view
+pub fn render(f: &mut Frame, area: Rect, state: &mut AppState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),  // Header
+            Constraint::Min(10),   // DHT records table
+            Constraint::Length(12), // Selected record details
+            Constraint::Length(5),  // Footer with stats (3 content + 2 border)
+        ])
+        .split(area);
+
+    render_header(f, chunks[0]);
+
+    let row_data = build_rows(state);
+
+    // Clamp cursor
+    let max_row = row_data.len().saturating_sub(1);
+    state.dht_cursor = state.dht_cursor.min(max_row);
+
+    render_dht_table(f, chunks[1], state, &row_data);
+    render_details(f, chunks[2], state, &row_data);
+    render_footer(f, chunks[3], state);
+}
+
+fn render_header(f: &mut Frame, area: Rect) {
+    let header = Paragraph::new(vec![Line::from(vec![
+        Span::styled(
+            "DHT Debug View ",
+            Style::default()
+                .fg(COLOR_BRAND)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("(for nerds)", Style::default().fg(COLOR_LABEL)),
+        Span::raw("  "),
+        Span::styled("Kademlia DHT", Style::default().fg(COLOR_SUCCESS)),
+        Span::raw("  "),
+        Span::styled("X", Style::default().fg(COLOR_ACTIVE).add_modifier(Modifier::BOLD)),
+        Span::styled(":Query  ", Style::default().fg(COLOR_LABEL)),
+        Span::styled("G", Style::default().fg(COLOR_ACTIVE).add_modifier(Modifier::BOLD)),
+        Span::styled(":Custom GET  ", Style::default().fg(COLOR_LABEL)),
+        Span::styled("Up/Down", Style::default().fg(COLOR_ACTIVE).add_modifier(Modifier::BOLD)),
+        Span::styled(":Navigate", Style::default().fg(COLOR_LABEL)),
+    ])])
+    .block(Block::default().borders(Borders::ALL));
+
+    f.render_widget(header, area);
+}
+
+fn render_dht_table(f: &mut Frame, area: Rect, state: &AppState, row_data: &[(Row<'static>, DhtRow)]) {
+    let header = Row::new(vec!["Source", "Type", "Identifier", "Address", "Info"])
+        .style(Style::default().fg(COLOR_ACTIVE))
+        .bottom_margin(1);
+
+    let cursor = state.dht_cursor;
+
+    let styled_rows: Vec<Row> = row_data.iter().enumerate().map(|(i, (row, meta))| {
+        let is_selected = i == cursor;
+
+        // Base style for this row type
+        let base_style = match meta {
+            DhtRow::BucketHeader { .. } => Style::default().fg(COLOR_INFO).add_modifier(Modifier::BOLD),
+            DhtRow::DhtPeer { .. } => Style::default().fg(COLOR_BRAND),
+            DhtRow::SectionHeader { .. } => Style::default().fg(COLOR_ACTIVE).add_modifier(Modifier::BOLD),
+            DhtRow::ConsensusRecord { .. } => Style::default().fg(COLOR_ACTIVE),
+            DhtRow::KnownPeer { .. } => Style::default().fg(COLOR_INFO),
+            DhtRow::Empty => Style::default().fg(COLOR_MUTED),
+        };
+
+        // Override with selection highlight
+        let style = if is_selected {
+            Style::default().fg(COLOR_SUCCESS).add_modifier(Modifier::BOLD | Modifier::REVERSED)
+        } else {
+            base_style
+        };
+
+        row.clone().style(style)
+    }).collect();
+
+    let table = Table::new(
+        styled_rows,
+        [
+            Constraint::Length(14),
+            Constraint::Length(12),
+            Constraint::Percentage(30),
+            Constraint::Percentage(30),
+            Constraint::Percentage(15),
+        ],
+    )
+    .header(header)
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("DHT Records (Kademlia Distributed Hash Table)"),
+    );
+
+    f.render_widget(table, area);
+}
+
+fn render_details(f: &mut Frame, area: Rect, state: &AppState, row_data: &[(Row<'static>, DhtRow)]) {
+    let mut lines: Vec<Line> = Vec::new();
+
+    // Show info about the selected row
+    if let Some((_, meta)) = row_data.get(state.dht_cursor) {
+        match meta {
+            DhtRow::BucketHeader { bucket_idx, peer_count } => {
+                if let Some(snapshot) = &state.dht_snapshot {
+                    if let Some(bucket) = snapshot.buckets.get(*bucket_idx) {
+                        lines.push(Line::from(vec![
+                            Span::styled("K-Bucket #", Style::default().fg(COLOR_ACTIVE)),
+                            Span::styled(format!("{}", bucket.index), Style::default().fg(COLOR_ACTIVE).add_modifier(Modifier::BOLD)),
+                            Span::styled(format!("  ({} peers)", peer_count), Style::default().fg(COLOR_LABEL)),
+                        ]));
+                        lines.push(Line::from(""));
+                        // List all peers in this bucket
+                        for (i, peer) in bucket.peers.iter().enumerate() {
+                            let prefix = if i == 0 { "  Peers: " } else { "         " };
+                            lines.push(Line::from(vec![
+                                Span::styled(prefix, Style::default().fg(COLOR_LABEL)),
+                                Span::styled(&peer.peer_id, Style::default().fg(COLOR_BRAND)),
+                            ]));
+                            if !peer.addrs.is_empty() {
+                                for addr in &peer.addrs {
+                                    lines.push(Line::from(vec![
+                                        Span::raw("           "),
+                                        Span::styled(addr, Style::default().fg(COLOR_MUTED)),
+                                    ]));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            DhtRow::DhtPeer { bucket_idx, peer_idx } => {
+                if let Some(snapshot) = &state.dht_snapshot {
+                    if let Some(bucket) = snapshot.buckets.get(*bucket_idx) {
+                        if let Some(peer) = bucket.peers.get(*peer_idx) {
+                            lines.push(Line::from(vec![
+                                Span::styled("Peer ID: ", Style::default().fg(COLOR_BRAND)),
+                                Span::raw(&peer.peer_id),
+                            ]));
+                            lines.push(Line::from(vec![
+                                Span::styled("Bucket:  ", Style::default().fg(COLOR_BRAND)),
+                                Span::raw(format!("#{}", bucket.index)),
+                            ]));
+                            if peer.addrs.is_empty() {
+                                lines.push(Line::from(vec![
+                                    Span::styled("Addrs:   ", Style::default().fg(COLOR_LABEL)),
+                                    Span::styled("(none known)", Style::default().fg(COLOR_MUTED)),
+                                ]));
+                            } else {
+                                for (i, addr) in peer.addrs.iter().enumerate() {
+                                    let label = if i == 0 { "Addrs:   " } else { "         " };
+                                    lines.push(Line::from(vec![
+                                        Span::styled(label, Style::default().fg(COLOR_LABEL)),
+                                        Span::raw(addr),
+                                    ]));
+                                }
+                            }
+                            if let Some(ref st) = peer.state {
+                                lines.push(Line::from(vec![
+                                    Span::styled("State:   ", Style::default().fg(COLOR_LABEL)),
+                                    Span::raw(st),
+                                ]));
+                            }
+                        }
+                    }
+                }
+            }
+            DhtRow::ConsensusRecord { domain, votes, agreed } => {
+                lines.push(Line::from(vec![
+                    Span::styled("Domain:  ", Style::default().fg(COLOR_BRAND)),
+                    Span::raw(domain.as_str()),
+                ]));
+                lines.push(Line::from(vec![
+                    Span::styled("Votes:   ", Style::default().fg(COLOR_BRAND)),
+                    Span::raw(format!("{}", votes)),
+                ]));
+                lines.push(Line::from(vec![
+                    Span::styled("Status:  ", Style::default().fg(COLOR_BRAND)),
+                    if *agreed {
+                        Span::styled("Consensus reached", Style::default().fg(COLOR_SUCCESS))
+                    } else {
+                        Span::styled("Pending consensus", Style::default().fg(COLOR_ACTIVE))
+                    },
+                ]));
+            }
+            DhtRow::KnownPeer { peer_idx } => {
+                if let Some(peer) = state.peers.get(*peer_idx) {
+                    lines.push(Line::from(vec![
+                        Span::styled("Peer ID: ", Style::default().fg(COLOR_BRAND)),
+                        Span::raw(&peer.peer_id),
+                    ]));
+                    lines.push(Line::from(vec![
+                        Span::styled("Status:  ", Style::default().fg(COLOR_BRAND)),
+                        Span::raw(&peer.status),
+                    ]));
+                    let now = std::time::SystemTime::now();
+                    let seen = match now.duration_since(peer.last_seen) {
+                        Ok(elapsed) => format!("{}s ago", elapsed.as_secs()),
+                        Err(_) => "just now".to_string(),
+                    };
+                    lines.push(Line::from(vec![
+                        Span::styled("Seen:    ", Style::default().fg(COLOR_BRAND)),
+                        Span::raw(seen),
+                    ]));
+                    lines.push(Line::from(vec![
+                        Span::styled("Source:  ", Style::default().fg(COLOR_LABEL)),
+                        Span::styled("Database (peer table)", Style::default().fg(COLOR_MUTED)),
+                    ]));
+                }
+            }
+            DhtRow::SectionHeader { label } => {
+                lines.push(Line::from(vec![
+                    Span::styled("Section: ", Style::default().fg(COLOR_ACTIVE)),
+                    Span::styled(label.as_str(), Style::default().fg(COLOR_ACTIVE).add_modifier(Modifier::BOLD)),
+                ]));
+            }
+            DhtRow::Empty => {
+                lines.push(Line::from(Span::styled(
+                    "No data to display",
+                    Style::default().fg(COLOR_MUTED),
+                )));
+            }
+        }
+    }
+
+    // Append snapshot summary if available
+    if let Some(snapshot) = &state.dht_snapshot {
+        let total_peers: usize = snapshot.buckets.iter().map(|b| b.peers.len()).sum();
+        if lines.len() < 8 {
+            lines.push(Line::from(""));
+            lines.push(Line::from(vec![
+                Span::styled("Snapshot: ", Style::default().fg(COLOR_LABEL)),
+                Span::raw(format!("{} buckets, {} peers  ", snapshot.buckets.len(), total_peers)),
+                Span::styled("Local: ", Style::default().fg(COLOR_LABEL)),
+                Span::raw(truncate_peer_id(&snapshot.local_peer_id)),
+                Span::raw(format!("  ({})", format_timestamp(snapshot.captured_at))),
+            ]));
+        }
+    }
+
+    // Show last query result
+    if let Some((key, success)) = &state.dht_last_query {
+        if lines.len() < 9 {
+            let status_color = if *success { COLOR_SUCCESS } else { COLOR_ERROR };
+            let status_text = if *success { "[OK]" } else { "[NOT FOUND]" };
+            lines.push(Line::from(vec![
+                Span::styled("Last GET: ", Style::default().fg(COLOR_LABEL)),
+                Span::styled(status_text, Style::default().fg(status_color)),
+                Span::raw(" "),
+                Span::raw(key.as_str()),
+            ]));
+        }
+    }
+
+    if lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "No DHT snapshot available. Snapshots emit every ~30s when P2P is connected.",
+            Style::default().fg(COLOR_MUTED),
+        )));
+    }
+
+    let widget = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::ALL).title("Details"));
+    f.render_widget(widget, area);
+}
+
+fn render_footer(f: &mut Frame, area: Rect, state: &AppState) {
+    let peer_count = state.connected_peers;
+
+    let mut footer_lines = vec![];
+
+    // Line 1: DHT protocol stats
+    let dht_peers: usize = state.dht_snapshot.as_ref()
+        .map(|s| s.buckets.iter().map(|b| b.peers.len()).sum())
+        .unwrap_or(0);
+    footer_lines.push(Line::from(vec![
+        Span::styled("DHT Peers: ", Style::default().fg(COLOR_BRAND)),
+        Span::raw(format!("{}  ", dht_peers)),
+        Span::styled("Connected: ", Style::default().fg(COLOR_BRAND)),
+        Span::raw(format!("{}  ", peer_count)),
+        Span::styled("Protocol: ", Style::default().fg(COLOR_BRAND)),
+        Span::raw("Kademlia  "),
+        Span::styled("Replication: ", Style::default().fg(COLOR_BRAND)),
+        Span::raw("20"),
+    ]));
+
+    // Line 2: Query stats
+    let total_queries = state.dht_successful_queries + state.dht_failed_queries;
+    let success_rate = if total_queries > 0 {
+        (state.dht_successful_queries * 100) / total_queries
+    } else {
+        0
+    };
+    let success_color = if total_queries == 0 { COLOR_MUTED } else if success_rate > 80 { COLOR_SUCCESS } else if success_rate > 50 { COLOR_ACTIVE } else { COLOR_ERROR };
+    footer_lines.push(Line::from(vec![
+        Span::styled("Queries: ", Style::default().fg(COLOR_BRAND)),
+        Span::styled(format!("{} ok  ", state.dht_successful_queries), Style::default().fg(COLOR_SUCCESS)),
+        Span::styled(format!("{} fail  ", state.dht_failed_queries), Style::default().fg(COLOR_ERROR)),
+        Span::styled(format!("{} pending  ", state.dht_pending_queries), Style::default().fg(COLOR_ACTIVE)),
+        Span::styled("Success: ", Style::default().fg(COLOR_BRAND)),
+        Span::styled(format!("{}%", success_rate), Style::default().fg(success_color)),
+    ]));
+
+    // Line 3: Last query or help
+    if let Some((key, success)) = &state.dht_last_query {
+        let status_text = if *success { "[OK]" } else { "[MISS]" };
+        let status_color = if *success { COLOR_SUCCESS } else { COLOR_ERROR };
+        footer_lines.push(Line::from(vec![
+            Span::styled("Last: ", Style::default().fg(COLOR_LABEL)),
+            Span::styled(status_text, Style::default().fg(status_color)),
+            Span::raw(" "),
+            Span::raw(truncate_str(key, 60)),
+        ]));
+    } else {
+        footer_lines.push(Line::from(vec![
+            Span::styled("No queries yet. Press ", Style::default().fg(COLOR_LABEL)),
+            Span::styled("X", Style::default().fg(COLOR_ACTIVE).add_modifier(Modifier::BOLD)),
+            Span::styled(" to query a key.", Style::default().fg(COLOR_LABEL)),
+        ]));
+    }
+
+    let footer_widget = Paragraph::new(footer_lines)
+        .block(Block::default().borders(Borders::ALL).title("Query Stats"));
+
+    f.render_widget(footer_widget, area);
+}
+
+fn truncate_peer_id(id: &str) -> String {
+    if id.len() > 20 {
+        format!("{}..{}", &id[..8], &id[id.len()-8..])
+    } else {
+        id.to_string()
+    }
+}
+
+fn truncate_str(s: &str, max: usize) -> String {
+    if s.len() > max {
+        format!("{}...", &s[..max.saturating_sub(3)])
+    } else {
+        s.to_string()
+    }
+}
+
+fn format_timestamp(ts: i64) -> String {
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    let time = if ts >= 0 {
+        UNIX_EPOCH + Duration::from_secs(ts as u64)
+    } else {
+        return format!("{}", ts);
+    };
+    let elapsed = SystemTime::now().duration_since(time).unwrap_or(Duration::from_secs(0));
+    let secs = elapsed.as_secs();
+    if secs < 60 {
+        format!("{}s ago", secs)
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else {
+        format!("{}h {}m ago", secs / 3600, (secs % 3600) / 60)
+    }
+}

--- a/apps/service/src/tui/ui/distributed.rs
+++ b/apps/service/src/tui/ui/distributed.rs
@@ -1,0 +1,466 @@
+/// Distributed monitoring TUI components
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, Paragraph, Row, Table, Tabs},
+    Frame,
+};
+
+use crate::tui::state::AppState;
+
+/// Render distributed monitoring overview
+pub fn render_distributed_overview(f: &mut Frame, area: Rect, state: &AppState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),  // Header tabs
+            Constraint::Min(10),    // Main content
+            Constraint::Length(3),  // Summary footer
+        ])
+        .split(area);
+
+    // Tabs for different views
+    render_distributed_tabs(f, chunks[0], state);
+
+    // Main content based on selected tab
+    match state.distributed_tab {
+        DistributedTab::PublicMonitors => render_public_monitors(f, chunks[1], state),
+        DistributedTab::Consensus => render_pending_promotion(f, chunks[1], state),
+        DistributedTab::PeerGroups => render_peer_groups(f, chunks[1], state),
+        DistributedTab::RateLimits => render_rate_limits(f, chunks[1], state),
+    }
+
+    // Summary footer
+    render_distributed_summary(f, chunks[2], state);
+}
+
+/// Render tab selector
+fn render_distributed_tabs(f: &mut Frame, area: Rect, state: &AppState) {
+    let titles = vec!["Public Monitors", "Pending Promotion", "Peer Groups", "Rate Limits"];
+    let selected = state.distributed_tab as usize;
+
+    let tabs = Tabs::new(titles)
+        .block(Block::default().borders(Borders::ALL).title("Distributed Monitoring"))
+        .select(selected)
+        .style(Style::default().fg(Color::White))
+        .highlight_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    f.render_widget(tabs, area);
+}
+
+/// Render public monitors list
+fn render_public_monitors(f: &mut Frame, area: Rect, state: &AppState) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+
+    // Left: List of public monitors
+    let items: Vec<ListItem> = state
+        .public_monitors
+        .iter()
+        .enumerate()
+        .map(|(i, monitor)| {
+            let domain = monitor.public_domain.as_deref().unwrap_or("unknown");
+            let display_name = monitor
+                .public_display_name
+                .as_deref()
+                .unwrap_or(domain);
+            let check_type = &monitor.check_type;
+            let interval = monitor.interval_seconds;
+
+            let style = if i == state.selected_public_monitor {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+
+            let status_indicator = if monitor.enabled { "●" } else { "○" };
+            let status_color = if monitor.enabled {
+                Color::Green
+            } else {
+                Color::Gray
+            };
+
+            let content = Line::from(vec![
+                Span::styled(status_indicator, Style::default().fg(status_color)),
+                Span::raw(" "),
+                Span::styled(display_name, style),
+                Span::raw(" "),
+                Span::styled(
+                    format!("({})", check_type),
+                    Style::default().fg(Color::Cyan),
+                ),
+                Span::raw(" "),
+                Span::styled(
+                    format!("{}s", interval),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]);
+
+            ListItem::new(content)
+        })
+        .collect();
+
+    if items.is_empty() {
+        let empty = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled("No public monitors", Style::default().fg(Color::DarkGray))),
+            Line::from(""),
+            Line::from(Span::styled("Press Shift+A in Dashboard to add one", Style::default().fg(Color::Gray))),
+        ])
+        .block(Block::default().borders(Borders::ALL).title("Public Monitors (Community)"));
+        f.render_widget(empty, chunks[0]);
+    } else {
+        let list = List::new(items)
+            .block(Block::default().borders(Borders::ALL).title("Public Monitors (Community)"));
+        f.render_widget(list, chunks[0]);
+    }
+
+    // Right: Monitor details
+    if let Some(monitor) = state.public_monitors.get(state.selected_public_monitor) {
+        render_public_monitor_detail(f, chunks[1], monitor, state);
+    }
+}
+
+/// Render detailed view of selected public monitor
+fn render_public_monitor_detail(
+    f: &mut Frame,
+    area: Rect,
+    monitor: &crate::database::models::Monitor,
+    state: &AppState,
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(8), Constraint::Min(5)])
+        .split(area);
+
+    // Monitor info
+    let domain = monitor.public_domain.as_deref().unwrap_or("unknown");
+    let display_name = monitor
+        .public_display_name
+        .as_deref()
+        .unwrap_or(domain);
+
+    let info_text = vec![
+        Line::from(vec![
+            Span::styled("Display Name: ", Style::default().fg(Color::Cyan)),
+            Span::raw(display_name),
+        ]),
+        Line::from(vec![
+            Span::styled("Domain: ", Style::default().fg(Color::Cyan)),
+            Span::raw(domain),
+        ]),
+        Line::from(vec![
+            Span::styled("Target: ", Style::default().fg(Color::Cyan)),
+            Span::raw(&monitor.target),
+        ]),
+        Line::from(vec![
+            Span::styled("Check Type: ", Style::default().fg(Color::Cyan)),
+            Span::raw(&monitor.check_type),
+        ]),
+        Line::from(vec![
+            Span::styled("Interval: ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{}s", monitor.interval_seconds)),
+        ]),
+        Line::from(vec![
+            Span::styled("Timeout: ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{}s", monitor.timeout_seconds)),
+        ]),
+    ];
+
+    let info = Paragraph::new(info_text).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("Monitor Details"),
+    );
+
+    f.render_widget(info, chunks[0]);
+
+    // Peer coordination info
+    if let Some(group) = state
+        .public_monitor_groups
+        .iter()
+        .find(|g| g.domain == domain)
+    {
+        let peer_info = vec![
+            Line::from(vec![
+                Span::styled("Participating Peers: ", Style::default().fg(Color::Green)),
+                Span::raw(group.participating_peers.len().to_string()),
+            ]),
+            Line::from(vec![
+                Span::styled("Check Schedule: ", Style::default().fg(Color::Green)),
+                Span::raw(format!(
+                    "Every {}s, staggered across peers",
+                    group.schedule.interval_seconds
+                )),
+            ]),
+            Line::from(vec![
+                Span::styled("Total Checks: ", Style::default().fg(Color::Green)),
+                Span::raw(group.total_checks.to_string()),
+            ]),
+        ];
+
+        let coordination = Paragraph::new(peer_info).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Coordination Status"),
+        );
+
+        f.render_widget(coordination, chunks[1]);
+    }
+}
+
+/// Render monitors pending promotion (below threshold)
+fn render_pending_promotion(f: &mut Frame, area: Rect, state: &AppState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(10), Constraint::Length(5)])
+        .split(area);
+
+    // Pending promotion table
+    let header = Row::new(vec!["Domain", "Interest Count", "Status", "Last Update"])
+        .style(Style::default().fg(Color::Yellow))
+        .bottom_margin(1);
+
+    let rows: Vec<Row> = state
+        .consensus_states
+        .iter()
+        .map(|(domain, consensus)| {
+            let interest_count = consensus.pending_votes.len(); // Reinterpret as interest signals
+            let threshold = 5;
+            let is_promoted = interest_count >= threshold;
+            let status_text = if is_promoted { 
+                "✓ Promoted" 
+            } else { 
+                &format!("{}/{}", interest_count, threshold)
+            };
+            let status_color = if is_promoted {
+                Color::Green
+            } else {
+                Color::Red
+            };
+
+            Row::new(vec![
+                domain.clone(),
+                interest_count.to_string(),
+                status_text.to_string(),
+                "Recently".to_string(), // TODO: Format timestamp
+            ])
+            .style(Style::default().fg(status_color))
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Percentage(40),
+            Constraint::Percentage(20),
+            Constraint::Percentage(20),
+            Constraint::Percentage(20),
+        ],
+    )
+    .header(header)
+    .block(Block::default().borders(Borders::ALL).title("Pending Promotion (Threshold: 5 peers)"))
+    .highlight_style(Style::default().add_modifier(Modifier::BOLD));
+
+    f.render_widget(table, chunks[0]);
+
+    // Promotion info
+    let info = Paragraph::new(vec![
+        Line::from(vec![
+            Span::styled("Quorum Threshold: ", Style::default().fg(Color::Cyan)),
+            Span::raw("67% of peers must agree"),
+        ]),
+        Line::from(vec![
+            Span::styled("Purpose: ", Style::default().fg(Color::Cyan)),
+            Span::raw("Coordinate check scheduling across peers"),
+        ]),
+    ])
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("Consensus Info"),
+    );
+
+    f.render_widget(info, chunks[1]);
+}
+
+/// Render peer groups
+fn render_peer_groups(f: &mut Frame, area: Rect, state: &AppState) {
+    let items: Vec<ListItem> = state
+        .public_monitor_groups
+        .iter()
+        .map(|group| {
+            let peer_count = group.participating_peers.len();
+            let interval = group.schedule.interval_seconds;
+            let checks = group.total_checks;
+
+            let content = Line::from(vec![
+                Span::styled(&group.display_name, Style::default().fg(Color::Yellow)),
+                Span::raw(" "),
+                Span::styled(
+                    format!("({} peers)", peer_count),
+                    Style::default().fg(Color::Green),
+                ),
+                Span::raw(" "),
+                Span::styled(
+                    format!("{}s interval", interval),
+                    Style::default().fg(Color::Cyan),
+                ),
+                Span::raw(" "),
+                Span::styled(
+                    format!("{} checks", checks),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]);
+
+            ListItem::new(content)
+        })
+        .collect();
+
+    if items.is_empty() {
+        let empty = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled("No peer groups formed yet", Style::default().fg(Color::DarkGray))),
+            Line::from(Span::styled("Groups form when peers coordinate on public monitors", Style::default().fg(Color::Gray))),
+        ])
+        .block(Block::default().borders(Borders::ALL).title("Public Monitor Groups"));
+        f.render_widget(empty, area);
+    } else {
+        let list = List::new(items)
+            .block(Block::default().borders(Borders::ALL).title("Public Monitor Groups"));
+        f.render_widget(list, area);
+    }
+}
+
+/// Render rate limit status
+fn render_rate_limits(f: &mut Frame, area: Rect, state: &AppState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(6), Constraint::Min(5)])
+        .split(area);
+
+    // Rate limit configuration
+    let config = vec![
+        Line::from(vec![
+            Span::styled(
+                "Minimum Check Interval: ",
+                Style::default().fg(Color::Cyan),
+            ),
+            Span::raw("10 seconds"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "Maximum Checks/Hour/Peer: ",
+                Style::default().fg(Color::Cyan),
+            ),
+            Span::raw("360 (1 every 10s)"),
+        ]),
+        Line::from(vec![
+            Span::styled("Purpose: ", Style::default().fg(Color::Cyan)),
+            Span::raw("Prevent DDoS and resource exhaustion"),
+        ]),
+        Line::from(vec![
+            Span::styled("Status: ", Style::default().fg(Color::Green)),
+            Span::styled("✓ ENFORCED", Style::default().fg(Color::Green)),
+        ]),
+    ];
+
+    let config_widget = Paragraph::new(config).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("Rate Limit Configuration"),
+    );
+
+    f.render_widget(config_widget, chunks[0]);
+
+    // Per-peer stats (if available)
+    if !state.rate_limit_stats.is_empty() {
+        let header = Row::new(vec!["Peer ID", "Checks This Hour", "Status"])
+            .style(Style::default().fg(Color::Yellow))
+            .bottom_margin(1);
+
+        let rows: Vec<Row> = state
+            .rate_limit_stats
+            .iter()
+            .map(|(peer_id, count)| {
+                let status = if *count < 360 { "OK" } else { "LIMITED" };
+                let status_color = if *count < 360 {
+                    Color::Green
+                } else {
+                    Color::Red
+                };
+
+                Row::new(vec![peer_id.clone(), count.to_string(), status.to_string()])
+                    .style(Style::default().fg(status_color))
+            })
+            .collect();
+
+        let table = Table::new(
+            rows,
+            [
+                Constraint::Percentage(50),
+                Constraint::Percentage(30),
+                Constraint::Percentage(20),
+            ],
+        )
+        .header(header)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Per-Peer Rate Limits"),
+        );
+
+        f.render_widget(table, chunks[1]);
+    }
+}
+
+/// Render summary footer
+fn render_distributed_summary(f: &mut Frame, area: Rect, state: &AppState) {
+    let public_count = state.public_monitors.len();
+    let private_count = state.monitors.len() - public_count;
+    let group_count = state.public_monitor_groups.len();
+    let consensus_count = state.consensus_states.len();
+
+    let summary = Line::from(vec![
+        Span::styled("Public: ", Style::default().fg(Color::Green)),
+        Span::raw(format!("{} ", public_count)),
+        Span::styled("│ Private: ", Style::default().fg(Color::Cyan)),
+        Span::raw(format!("{} ", private_count)),
+        Span::styled("│ Groups: ", Style::default().fg(Color::Yellow)),
+        Span::raw(format!("{} ", group_count)),
+        Span::styled("│ Consensus: ", Style::default().fg(Color::Magenta)),
+        Span::raw(format!("{}", consensus_count)),
+    ]);
+
+    let summary_widget = Paragraph::new(summary).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("Summary"),
+    );
+
+    f.render_widget(summary_widget, area);
+}
+
+/// Distributed monitoring tab enum
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DistributedTab {
+    PublicMonitors,
+    Consensus,
+    PeerGroups,
+    RateLimits,
+}
+
+impl Default for DistributedTab {
+    fn default() -> Self {
+        Self::PublicMonitors
+    }
+}

--- a/apps/service/src/tui/ui/header.rs
+++ b/apps/service/src/tui/ui/header.rs
@@ -1,36 +1,91 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Clear, Paragraph};
 
-use crate::tui::state::AppState;
+use super::{COLOR_ACTIVE, COLOR_BRAND, COLOR_ERROR, COLOR_INFO, COLOR_LABEL, COLOR_MUTED, COLOR_SUCCESS};
+use crate::tui::state::{AppState, StatusLevel};
+use crate::tui::types::ViewMode;
 
 pub fn render(f: &mut Frame, area: Rect, state: &AppState) {
-    let p2p_status = if state.p2p_enabled {
-        format!("P2P: Connected ({})", &state.peer_id[..state.peer_id.len().min(8)])
-    } else {
-        "P2P: Disabled".to_string()
-    };
+    // Row 1: Brand + view tabs
+    let mut tab_spans = vec![
+        Span::styled("Uppe. ", Style::default().fg(COLOR_BRAND).add_modifier(Modifier::BOLD)),
+        Span::styled(" ", Style::default()),
+    ];
 
-    let status = format!(
-        "Auto-refresh: {}  Monitors: {}  Results: {}  Last: {}s  {}",
-        if state.auto_refresh { "On" } else { "Off" },
-        state.monitors.len(),
-        state.results.len(),
-        state.last_refresh.elapsed().as_secs(),
-        p2p_status
-    );
+    let views = [
+        (ViewMode::Dashboard, "1:Dashboard"),
+        (ViewMode::Distributed, "2:Distributed"),
+        (ViewMode::Statistics, "3:Stats"),
+        (ViewMode::Network, "4:Network"),
+        (ViewMode::DhtDebug, "5:DHT"),
+        (ViewMode::AdminKeys, "6:Admin"),
+    ];
+
+    for (i, (mode, label)) in views.iter().enumerate() {
+        if i > 0 {
+            tab_spans.push(Span::styled(" | ", Style::default().fg(COLOR_MUTED)));
+        }
+        let style = if state.view_mode == *mode {
+            Style::default().fg(COLOR_ACTIVE).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(COLOR_LABEL)
+        };
+        tab_spans.push(Span::styled(*label, style));
+    }
+
+    // Row 2: Status bar
+    let mut status_spans = vec![];
+
+    // P2P status
+    if state.p2p_enabled {
+        let peer_short = &state.peer_id[..state.peer_id.len().min(8)];
+        status_spans.push(Span::styled(
+            format!("[P2P:{peer_short}..] "),
+            Style::default().fg(COLOR_SUCCESS),
+        ));
+        status_spans.push(Span::styled(
+            format!("{}peers ", state.connected_peers),
+            Style::default().fg(COLOR_LABEL),
+        ));
+    } else {
+        status_spans.push(Span::styled("[P2P:off] ", Style::default().fg(COLOR_MUTED)));
+    }
+
+    // Monitor/result counts
+    status_spans.push(Span::styled(
+        format!("{}mon {}res ", state.monitors.len(), state.results.len()),
+        Style::default().fg(COLOR_LABEL),
+    ));
+
+    // Auto-refresh indicator
+    if state.auto_refresh {
+        let secs = state.last_refresh.elapsed().as_secs();
+        status_spans.push(Span::styled(
+            format!("[auto:{secs}s] "),
+            Style::default().fg(COLOR_MUTED),
+        ));
+    }
+
+    // Status notification (overrides right side when present)
+    if let Some((msg, _, level)) = &state.status_message {
+        let color = match level {
+            StatusLevel::Success => COLOR_SUCCESS,
+            StatusLevel::Error => COLOR_ERROR,
+            StatusLevel::Info => COLOR_INFO,
+        };
+        status_spans.push(Span::styled(
+            format!(" -- {msg}"),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ));
+    }
 
     let header = Paragraph::new(vec![
-        Line::from(vec![
-            Span::styled(
-                "Uppe. Dashboard ",
-                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
-            ),
-            Span::raw("— 4-Pane View (Monitors | Results | Stats | Network)"),
-        ]),
-        Line::from(Span::styled(status, Style::default().fg(Color::Gray))),
+        Line::from(tab_spans),
+        Line::from(""),
+        Line::from(status_spans),
     ]);
 
     f.render_widget(Clear, area);

--- a/apps/service/src/tui/ui/mod.rs
+++ b/apps/service/src/tui/ui/mod.rs
@@ -1,3 +1,5 @@
+pub mod dht_debug;
+pub mod distributed;
 pub mod footer;
 pub mod header;
 pub mod monitors;
@@ -5,12 +7,23 @@ pub mod network;
 pub mod popups;
 pub mod results;
 pub mod stats;
+pub mod admin_keys;
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::Color;
+
+// Semantic color palette — use these instead of hardcoded colors
+pub const COLOR_BRAND: Color = Color::Cyan;
+pub const COLOR_ACTIVE: Color = Color::Yellow;
+pub const COLOR_SUCCESS: Color = Color::Green;
+pub const COLOR_ERROR: Color = Color::Red;
+pub const COLOR_MUTED: Color = Color::DarkGray;
+pub const COLOR_LABEL: Color = Color::Gray;
+pub const COLOR_INFO: Color = Color::Blue;
 
 use crate::tui::state::AppState;
-use crate::tui::types::FrameAreas;
+use crate::tui::types::{FrameAreas, ViewMode};
 
 /// Render the entire UI
 pub fn render(f: &mut Frame, state: &mut AppState) {
@@ -19,17 +32,65 @@ pub fn render(f: &mut Frame, state: &mut AppState) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(1)
-        .constraints([Constraint::Length(2), Constraint::Min(1), Constraint::Length(2)])
+        .constraints([Constraint::Length(3), Constraint::Min(1), Constraint::Length(1)])
         .split(size);
 
-    // Render header
+    // Render header (3 lines: brand+tabs, status bar, separator)
     header::render(f, chunks[0], state);
 
-    // Create 2x2 grid layout for main content
+    // Render main content based on view mode
+    match state.view_mode {
+        ViewMode::Dashboard => {
+            render_dashboard(f, chunks[1], state, chunks[0]);
+        }
+        ViewMode::Distributed => {
+            distributed::render_distributed_overview(f, chunks[1], state);
+        }
+        ViewMode::Statistics => {
+            stats::render(f, chunks[1], state);
+        }
+        ViewMode::Network => {
+            network::render(f, chunks[1], state);
+        }
+        ViewMode::DhtDebug => {
+            dht_debug::render(f, chunks[1], state);
+        }
+        ViewMode::AdminKeys => {
+            admin_keys::render(f, chunks[1], state);
+        }
+    }
+
+    // Render footer (dynamic per view)
+    footer::render(f, chunks[2], state);
+
+    // Render popups (overlays) - these appear on top of any view
+    if state.show_help {
+        popups::help::render(f, size);
+    }
+
+    if state.show_edit {
+        popups::edit::render(f, size, state);
+    }
+
+    if state.show_delete_confirm {
+        popups::delete::render(f, size, state);
+    }
+
+    if state.show_result_detail {
+        popups::result_detail::render(f, size, state);
+    }
+
+    if state.show_dht_query_popup {
+        popups::dht_query::render(f, size, state);
+    }
+}
+
+/// Render the dashboard 2x2 grid layout
+fn render_dashboard(f: &mut Frame, area: ratatui::layout::Rect, state: &mut AppState, header_area: ratatui::layout::Rect) {
     let grid = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .split(chunks[1]);
+        .split(area);
 
     let top_panes = Layout::default()
         .direction(Direction::Horizontal)
@@ -47,32 +108,12 @@ pub fn render(f: &mut Frame, state: &mut AppState) {
     stats::render(f, bottom_panes[0], state);
     network::render(f, bottom_panes[1], state);
 
-    // Render footer
-    let action_buttons = footer::render(f, chunks[2], state.show_help);
-
     // Store frame areas for mouse hit-testing
     state.areas = Some(FrameAreas {
-        header: chunks[0],
+        header: header_area,
         monitors: top_panes[0],
         results: top_panes[1],
-        footer: chunks[2],
-        action_buttons,
+        footer: ratatui::layout::Rect::default(),
+        action_buttons: vec![],
     });
-
-    // Render popups (overlays)
-    if state.show_help {
-        popups::help::render(f, size);
-    }
-
-    if state.show_edit {
-        popups::edit::render(f, size, state);
-    }
-
-    if state.show_delete_confirm {
-        popups::delete::render(f, size, state);
-    }
-
-    if state.show_result_detail {
-        popups::result_detail::render(f, size, state);
-    }
 }

--- a/apps/service/src/tui/ui/monitors.rs
+++ b/apps/service/src/tui/ui/monitors.rs
@@ -1,42 +1,89 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, List, ListItem};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph};
 
+use super::{COLOR_ACTIVE, COLOR_BRAND, COLOR_ERROR, COLOR_LABEL, COLOR_MUTED, COLOR_SUCCESS};
+use crate::database::models::MonitorVisibility;
 use crate::tui::state::AppState;
 use crate::tui::types::Focus;
 
 pub fn render(f: &mut Frame, area: Rect, state: &AppState) {
+    let focused = state.focus == Focus::Monitors;
+    let border_style = if focused {
+        Style::default().fg(COLOR_ACTIVE)
+    } else {
+        Style::default().fg(COLOR_BRAND)
+    };
+
+    let title = if focused { " Monitors (focused) " } else { " Monitors " };
+
+    if state.monitors.is_empty() {
+        let empty = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled("No monitors configured", Style::default().fg(COLOR_MUTED))),
+            Line::from(""),
+            Line::from(Span::styled("Press 'a' to add a private monitor", Style::default().fg(COLOR_LABEL))),
+            Line::from(Span::styled("Press 'A' to add a public monitor", Style::default().fg(COLOR_LABEL))),
+        ])
+        .block(Block::default().borders(Borders::ALL).title(title).border_style(border_style));
+
+        f.render_widget(Clear, area);
+        f.render_widget(empty, area);
+        return;
+    }
+
+    // Available width for content (minus borders)
+    let inner_width = area.width.saturating_sub(2) as usize;
+
     let items: Vec<ListItem> = state
         .monitors
         .iter()
         .enumerate()
         .map(|(i, m)| {
             let selected = i == state.selected;
-            let style = if selected {
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+            let name_style = if selected {
+                Style::default().fg(COLOR_ACTIVE).add_modifier(Modifier::BOLD)
             } else {
                 Style::default()
             };
 
+            let status_char = if m.enabled { "+" } else { "-" };
+            let status_color = if m.enabled { COLOR_SUCCESS } else { COLOR_ERROR };
+
+            let vis = match m.visibility {
+                MonitorVisibility::Public => "Pub",
+                MonitorVisibility::Private => "Prv",
+                MonitorVisibility::Internal => "Int",
+            };
+
+            // Build: [+] Name [Pub] type -> target
+            let prefix = format!("[{}] ", status_char);
+            let vis_badge = format!(" [{}] ", vis);
+            let type_target = format!("{} -> ", m.check_type);
+
+            // Calculate remaining space for target
+            let fixed_len = prefix.len() + m.name.len() + vis_badge.len() + type_target.len();
+            let target = if fixed_len + m.target.len() > inner_width && inner_width > fixed_len + 3 {
+                let max = inner_width - fixed_len - 2;
+                format!("{}..", &m.target[..max.min(m.target.len())])
+            } else {
+                m.target.clone()
+            };
+
             ListItem::new(Line::from(vec![
-                Span::styled(m.name.to_string(), style),
-                Span::styled(
-                    if m.enabled { "  ✓ " } else { "  ✗ " },
-                    Style::default().fg(if m.enabled { Color::Green } else { Color::Red }),
-                ),
-                Span::raw(format!(" [{}]", m.check_type)),
-                Span::raw(format!("  -> {}", m.target)),
+                Span::styled(prefix, Style::default().fg(status_color)),
+                Span::styled(m.name.clone(), name_style),
+                Span::styled(vis_badge, Style::default().fg(COLOR_MUTED)),
+                Span::styled(type_target, Style::default().fg(COLOR_LABEL)),
+                Span::raw(target),
             ]))
         })
         .collect();
 
-    let monitors_title =
-        if state.focus == Focus::Monitors { "Monitors (focused)" } else { "Monitors" };
-
-    let monitors_list =
-        List::new(items).block(Block::default().borders(Borders::ALL).title(monitors_title));
+    let monitors_list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(title).border_style(border_style));
 
     f.render_widget(Clear, area);
     f.render_widget(monitors_list, area);

--- a/apps/service/src/tui/ui/network.rs
+++ b/apps/service/src/tui/ui/network.rs
@@ -1,92 +1,131 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
+use super::{COLOR_ACTIVE, COLOR_BRAND, COLOR_ERROR, COLOR_LABEL, COLOR_MUTED, COLOR_SUCCESS};
 use crate::tui::state::AppState;
+use crate::tui::types::Focus;
 
 pub fn render(f: &mut Frame, area: Rect, state: &AppState) {
-    let focus_style = if state.focus == crate::tui::types::Focus::Network {
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+    let focused = state.focus == Focus::Network;
+    let border_style = if focused {
+        Style::default().fg(COLOR_ACTIVE)
     } else {
-        Style::default().fg(Color::Cyan)
+        Style::default().fg(COLOR_BRAND)
     };
 
-    let title = if state.focus == crate::tui::types::Focus::Network {
-        "Network (focused)"
-    } else {
-        "Network & P2P"
-    };
+    let title = if focused { " Network (focused) " } else { " Network " };
 
     let mut lines = vec![];
 
-    let node_status = if state.p2p_enabled {
-        Span::styled(
-            format!("Node ID: {}...", state.peer_id.chars().take(16).collect::<String>()),
-            Style::default().fg(Color::Green),
-        )
-    } else {
-        Span::styled("P2P: Disabled", Style::default().fg(Color::Red))
-    };
-
-    lines.push(Line::from(node_status));
-
-    let status_text = if state.p2p_enabled { "✓ Connected" } else { "✗ Offline" };
-    let status_color = if state.p2p_enabled { Color::Green } else { Color::Red };
-
-    lines.push(Line::from(vec![
-        Span::raw("Status:  "),
-        Span::styled(status_text, Style::default().fg(status_color)),
-    ]));
-
     if state.p2p_enabled {
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled("Peers", Style::default().fg(Color::Yellow))));
-        lines.push(Line::from(format!("  Connected: {}", state.connected_peers)));
-        lines.push(Line::from(format!("  Total Seen: {}", state.total_peers_seen)));
-
-        let health_pct = if state.total_peers_seen > 0 {
-            (state.connected_peers * 100) / state.total_peers_seen.max(1)
-        } else {
-            0
-        };
-        let health_color = if health_pct > 80 {
-            Color::Green
-        } else if health_pct > 50 {
-            Color::Yellow
-        } else {
-            Color::Red
-        };
+        // Node ID
+        let peer_short: String = state.peer_id.chars().take(12).collect();
         lines.push(Line::from(vec![
-            Span::raw("  Health:    "),
-            Span::styled(format!("{health_pct}%"), Style::default().fg(health_color)),
+            Span::styled("Node: ", Style::default().fg(COLOR_LABEL)),
+            Span::styled(format!("{peer_short}.."), Style::default().fg(COLOR_SUCCESS)),
         ]));
 
+        // Connection status
+        if state.connected_peers == 0 {
+            lines.push(Line::from(Span::styled(
+                "  Connecting...",
+                Style::default().fg(COLOR_ACTIVE),
+            )));
+        } else {
+            let health_pct = if state.total_peers_seen > 0 {
+                (state.connected_peers * 100) / state.total_peers_seen.max(1)
+            } else {
+                0
+            };
+            let health_color = if health_pct > 80 {
+                COLOR_SUCCESS
+            } else if health_pct > 50 {
+                COLOR_ACTIVE
+            } else {
+                COLOR_ERROR
+            };
+
+            lines.push(Line::from(vec![
+                Span::styled("  Peers: ", Style::default().fg(COLOR_LABEL)),
+                Span::raw(format!("{} connected", state.connected_peers)),
+                Span::styled(format!(" / {} seen", state.total_peers_seen), Style::default().fg(COLOR_MUTED)),
+                Span::raw("  "),
+                Span::styled(format!("{health_pct}%"), Style::default().fg(health_color)),
+            ]));
+        }
+
+        // Activity
         lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled("Activity", Style::default().fg(Color::Yellow))));
-        lines.push(Line::from(format!("  Shared:    {} results", state.results_shared)));
-        lines.push(Line::from(format!("  Received:  {} results", state.results_received)));
+        lines.push(Line::from(Span::styled(
+            "Activity",
+            Style::default().fg(COLOR_ACTIVE).add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(vec![
+            Span::styled("  Shared:   ", Style::default().fg(COLOR_LABEL)),
+            Span::raw(format!("{} results", state.results_shared)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("  Received: ", Style::default().fg(COLOR_LABEL)),
+            Span::raw(format!("{} results", state.results_received)),
+        ]));
 
         if let Some(ref event) = state.last_peer_event {
-            lines.push(Line::from(""));
             lines.push(Line::from(vec![
-                Span::styled("Last Event: ", Style::default().fg(Color::Cyan)),
-                Span::raw(event),
+                Span::styled("  Last:     ", Style::default().fg(COLOR_LABEL)),
+                Span::styled(event.clone(), Style::default().fg(COLOR_MUTED)),
+            ]));
+        }
+
+        // Retention/Sync
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Maintenance",
+            Style::default().fg(COLOR_ACTIVE).add_modifier(Modifier::BOLD),
+        )));
+
+        let (priv_days, pub_days, peer_days) = state.retention_policy_days;
+        lines.push(Line::from(vec![
+            Span::styled("  Retention: ", Style::default().fg(COLOR_LABEL)),
+            Span::raw(format!("{priv_days}d prv / {pub_days}d pub / {peer_days}d peer")),
+        ]));
+
+        if let Some(last_cleanup) = state.last_retention_cleanup {
+            let mins_ago = last_cleanup.elapsed().as_secs() / 60;
+            lines.push(Line::from(vec![
+                Span::styled("  Cleanup:   ", Style::default().fg(COLOR_LABEL)),
+                Span::raw(format!("{}m ago", mins_ago)),
+            ]));
+        }
+
+        if let Some(last_sync) = state.last_owner_sync {
+            let mins_ago = last_sync.elapsed().as_secs() / 60;
+            let time_str = if mins_ago >= 60 { format!("{}h ago", mins_ago / 60) } else { format!("{}m ago", mins_ago) };
+            lines.push(Line::from(vec![
+                Span::styled("  Sync:      ", Style::default().fg(COLOR_LABEL)),
+                Span::raw(time_str),
             ]));
         }
     } else {
-        lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "P2P networking is disabled",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(COLOR_MUTED),
         )));
-        lines.push(Line::from(Span::raw("Enable in config to share")));
-        lines.push(Line::from(Span::raw("and receive monitoring data")));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Enable P2P in your config to share",
+            Style::default().fg(COLOR_LABEL),
+        )));
+        lines.push(Line::from(Span::styled(
+            "and receive monitoring data",
+            Style::default().fg(COLOR_LABEL),
+        )));
     }
 
     let widget = Paragraph::new(lines)
-        .block(Block::default().borders(Borders::ALL).title(title).border_style(focus_style));
+        .block(Block::default().borders(Borders::ALL).title(title).border_style(border_style));
 
     f.render_widget(widget, area);
 }

--- a/apps/service/src/tui/ui/popups/dht_query.rs
+++ b/apps/service/src/tui/ui/popups/dht_query.rs
@@ -1,0 +1,59 @@
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+use crate::tui::state::AppState;
+
+pub fn render(f: &mut Frame, size: Rect, state: &AppState) {
+    let vchunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(30),
+            Constraint::Percentage(40),
+            Constraint::Percentage(30),
+        ])
+        .split(size);
+
+    let hchunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(20),
+            Constraint::Percentage(60),
+            Constraint::Percentage(20),
+        ])
+        .split(vchunks[1]);
+
+    let area = hchunks[1];
+
+    let mut lines = vec![
+        Line::from(Span::styled(
+            "DHT GET Query",
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Key: ", Style::default().fg(Color::Yellow)),
+            Span::raw(state.dht_query_input.clone()),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Enter to query, Esc to cancel",
+            Style::default().fg(Color::Gray),
+        )),
+    ];
+
+    if state.dht_query_input.is_empty() {
+        lines.insert(3, Line::from(Span::styled(
+            "(type a DHT key, e.g., /uppe/public-monitor/<domain>)",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    let popup = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::ALL).title("DHT GET"));
+
+    f.render_widget(Clear, area);
+    f.render_widget(popup, area);
+}

--- a/apps/service/src/tui/ui/popups/edit.rs
+++ b/apps/service/src/tui/ui/popups/edit.rs
@@ -1,105 +1,150 @@
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
 use crate::tui::state::AppState;
+use crate::tui::ui::{COLOR_ACTIVE, COLOR_BRAND, COLOR_ERROR, COLOR_LABEL, COLOR_MUTED};
 
 pub fn render(f: &mut Frame, size: Rect, state: &AppState) {
-    if let Some(m) = &state.edit_monitor {
-        let vchunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Percentage(20),
-                Constraint::Percentage(60),
-                Constraint::Percentage(20),
-            ])
-            .split(size);
+    let Some(m) = &state.edit_monitor else { return };
 
-        let hchunks = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Percentage(20),
-                Constraint::Percentage(60),
-                Constraint::Percentage(20),
-            ])
-            .split(vchunks[1]);
+    use crate::database::models::MonitorVisibility;
+    let is_public = matches!(m.visibility, MonitorVisibility::Public);
 
-        let area = hchunks[1];
+    let vchunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(15),
+            Constraint::Percentage(70),
+            Constraint::Percentage(15),
+        ])
+        .split(size);
 
-        let title = if state.is_add_form { "Add Monitor" } else { "Edit Monitor" };
+    let hchunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(15),
+            Constraint::Percentage(70),
+            Constraint::Percentage(15),
+        ])
+        .split(vchunks[1]);
 
-        let labels = ["Name", "Target", "Type", "Interval (s)", "Timeout (s)", "Enabled"];
-        let values = [
-            m.name.clone(),
-            m.target.clone(),
-            m.check_type.clone(),
-            format!("{}", m.interval_seconds),
-            format!("{}", m.timeout_seconds),
-            if m.enabled { "yes".into() } else { "no".into() },
-        ];
+    let area = hchunks[1];
 
-        let mut lines: Vec<Line> = Vec::new();
+    let title = if state.is_add_form { " Add Monitor " } else { " Edit Monitor " };
+
+    // Build field labels and values dynamically
+    let (labels, values): (Vec<&str>, Vec<String>) = if is_public {
+        (
+            vec!["Name", "Target", "Domain", "Display Name", "Type", "Interval (s)", "Timeout (s)", "Visibility", "Enabled"],
+            vec![
+                m.name.clone(),
+                m.target.clone(),
+                m.public_domain.as_ref().cloned().unwrap_or_default(),
+                m.public_display_name.as_ref().cloned().unwrap_or_default(),
+                m.check_type.clone(),
+                format!("{}", m.interval_seconds),
+                format!("{}", m.timeout_seconds),
+                "Public".to_string(),
+                if m.enabled { "yes".into() } else { "no".into() },
+            ],
+        )
+    } else {
+        (
+            vec!["Name", "Target", "Type", "Interval (s)", "Timeout (s)", "Visibility", "Enabled"],
+            vec![
+                m.name.clone(),
+                m.target.clone(),
+                m.check_type.clone(),
+                format!("{}", m.interval_seconds),
+                format!("{}", m.timeout_seconds),
+                "Private".to_string(),
+                if m.enabled { "yes".into() } else { "no".into() },
+            ],
+        )
+    };
+
+    let text_field_count = if is_public { 4 } else { 2 };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(Span::styled(
+        title.trim(),
+        Style::default().fg(COLOR_BRAND).add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(""));
+
+    for (i, (label, value)) in labels.iter().zip(values.iter()).enumerate() {
+        let is_selected = i == state.edit_field_index;
+        let prefix = if is_selected { "> " } else { "  " };
+        let field_style = if is_selected {
+            Style::default().fg(COLOR_ACTIVE)
+        } else {
+            Style::default()
+        };
+
+        // Show cursor in text fields
+        let display_value = if is_selected && i < text_field_count {
+            let mut v = value.clone();
+            if state.text_cursor <= v.len() {
+                v.insert(state.text_cursor, '|');
+            }
+            v
+        } else {
+            value.clone()
+        };
+
+        lines.push(Line::from(vec![
+            Span::raw(prefix),
+            Span::styled(format!("{label}: "), Style::default().fg(COLOR_LABEL)),
+            Span::styled(display_value, field_style),
+        ]));
+    }
+
+    lines.push(Line::from(""));
+
+    // Validation error
+    if let Some(err) = &state.validation_error {
         lines.push(Line::from(Span::styled(
-            title,
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            format!("! {err}"),
+            Style::default().fg(COLOR_ERROR).add_modifier(Modifier::BOLD),
         )));
         lines.push(Line::from(""));
-
-        for (i, (label, value)) in labels.iter().zip(values.iter()).enumerate() {
-            let prefix = if i == state.edit_field_index { "> " } else { "  " };
-            let field_style = if i == state.edit_field_index {
-                Style::default().fg(Color::Yellow)
-            } else {
-                Style::default()
-            };
-
-            // Show cursor position for text fields
-            let display_value = if i == state.edit_field_index && i < 2 {
-                let mut v = value.clone();
-                if state.text_cursor <= v.len() {
-                    v.insert(state.text_cursor, '|');
-                }
-                v
-            } else {
-                value.clone()
-            };
-
-            lines.push(Line::from(vec![
-                Span::raw(prefix),
-                Span::styled(format!("{label}: "), Style::default().fg(Color::Gray)),
-                Span::styled(display_value, field_style),
-            ]));
-        }
-
-        lines.push(Line::from(""));
-
-        // Show validation error if present
-        if let Some(err) = &state.validation_error {
-            lines.push(Line::from(Span::styled(
-                format!("⚠ {err}"),
-                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-            )));
-            lines.push(Line::from(""));
-        }
-
-        lines.push(Line::from(Span::styled("Navigation:", Style::default().fg(Color::Gray))));
-        lines.push(Line::from(
-            "  Tab/Shift-Tab/j/k: Next/Prev field  Left/Right/h/l: Move cursor/adjust",
-        ));
-        lines.push(Line::from("  Home/End: Jump to start/end of text"));
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled("Edit:", Style::default().fg(Color::Gray))));
-        lines.push(Line::from(
-            "  Type: edit text  +/- [ ]: adjust numbers  C: cycle type  Space: toggle",
-        ));
-        lines.push(Line::from("  Enter/S: Save  Esc: Cancel"));
-
-        let popup =
-            Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title("Edit"));
-
-        f.render_widget(Clear, area);
-        f.render_widget(popup, area);
     }
+
+    // Instructions
+    lines.push(Line::from(vec![
+        Span::styled("Tab/j/k", Style::default().fg(COLOR_BRAND)),
+        Span::styled(":fields  ", Style::default().fg(COLOR_LABEL)),
+        Span::styled("</>", Style::default().fg(COLOR_BRAND)),
+        Span::styled(":adjust  ", Style::default().fg(COLOR_LABEL)),
+        Span::styled("v", Style::default().fg(COLOR_BRAND)),
+        Span::styled(":visibility", Style::default().fg(COLOR_LABEL)),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("Enter", Style::default().fg(COLOR_BRAND)),
+        Span::styled(":save  ", Style::default().fg(COLOR_LABEL)),
+        Span::styled("Esc", Style::default().fg(COLOR_BRAND)),
+        Span::styled(":cancel  ", Style::default().fg(COLOR_LABEL)),
+        Span::styled("+/-", Style::default().fg(COLOR_BRAND)),
+        Span::styled(":interval  ", Style::default().fg(COLOR_LABEL)),
+        Span::styled("[/]", Style::default().fg(COLOR_BRAND)),
+        Span::styled(":timeout", Style::default().fg(COLOR_LABEL)),
+    ]));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        if is_public {
+            "Public: community-owned, threshold promotion (5 peers)"
+        } else {
+            "Private: your monitor, encrypted results via P2P"
+        },
+        Style::default().fg(COLOR_MUTED),
+    )));
+
+    let popup = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::ALL).title(title).border_style(Style::default().fg(COLOR_BRAND)));
+
+    f.render_widget(Clear, area);
+    f.render_widget(popup, area);
 }

--- a/apps/service/src/tui/ui/popups/help.rs
+++ b/apps/service/src/tui/ui/popups/help.rs
@@ -8,68 +8,128 @@ pub fn render(f: &mut Frame, size: Rect) {
     let vchunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Percentage(20),
-            Constraint::Percentage(60),
-            Constraint::Percentage(20),
+            Constraint::Percentage(10),
+            Constraint::Percentage(80),
+            Constraint::Percentage(10),
         ])
         .split(size);
 
     let hchunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Percentage(20),
-            Constraint::Percentage(60),
-            Constraint::Percentage(20),
+            Constraint::Percentage(15),
+            Constraint::Percentage(70),
+            Constraint::Percentage(15),
         ])
         .split(vchunks[1]);
 
     let area = hchunks[1];
 
+    let key = Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+    let section = Style::default().fg(Color::Yellow);
+
     let help_lines = vec![
         Line::from(Span::styled(
-            "Keybinds",
+            "Uppe. Keybinds",
             Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
-        Line::from(Span::styled("Navigation:", Style::default().fg(Color::Yellow))),
-        Line::from("  Up/Down, k/j      - Navigate in focused pane"),
-        Line::from("  Tab / Shift-Tab   - Cycle focus (Monitors → Results → Stats → Network)"),
-        Line::from("  Left/Right, h/l   - Jump focus (Monitors ↔ Results)"),
-        Line::from("  g/Home            - Jump to first"),
-        Line::from("  G/End             - Jump to last"),
+        Line::from(Span::styled("Views:", section)),
+        Line::from(vec![
+            Span::styled("  1", key), Span::raw(" Dashboard    "),
+            Span::styled("2", key), Span::raw(" Distributed  "),
+            Span::styled("3", key), Span::raw(" Statistics"),
+        ]),
+        Line::from(vec![
+            Span::styled("  4", key), Span::raw(" Network      "),
+            Span::styled("5", key), Span::raw(" DHT Debug    "),
+            Span::styled("6", key), Span::raw(" Admin Keys"),
+        ]),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("Tab", key), Span::raw("/"),
+            Span::styled("Shift-Tab", key), Span::raw(" cycle views"),
+        ]),
         Line::from(""),
-        Line::from(Span::styled("Actions:", Style::default().fg(Color::Yellow))),
-        Line::from("  A                 - Add monitor"),
-        Line::from("  E                 - Edit selected monitor"),
-        Line::from("  D                 - Delete selected monitor"),
-        Line::from("  Space/T           - Toggle enabled (Monitors list)"),
-        Line::from("  Enter             - View result details (Results list)"),
-        Line::from("  R                 - Refresh data"),
-        Line::from("  F                 - Toggle auto-refresh"),
+        Line::from(Span::styled("Navigation:", section)),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("j/k", key), Span::raw(" or "),
+            Span::styled("Up/Down", key), Span::raw("    navigate list"),
+        ]),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("h/l", key), Span::raw(" or "),
+            Span::styled("Left/Right", key), Span::raw(" switch panes/tabs"),
+        ]),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("g", key), Span::raw("/"),
+            Span::styled("Home", key), Span::raw(" first  "),
+            Span::styled("G", key), Span::raw("/"),
+            Span::styled("End", key), Span::raw(" last"),
+        ]),
         Line::from(""),
-        Line::from(Span::styled("Panes:", Style::default().fg(Color::Yellow))),
-        Line::from("  Top-Left    - Monitors list"),
-        Line::from("  Top-Right   - Recent results with latency & location"),
-        Line::from("  Bottom-Left - Statistics (uptime, success, latency)"),
-        Line::from("  Bottom-Right- Network & P2P (peers, bandwidth, score)"),
+        Line::from(Span::styled("Dashboard Actions:", section)),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("a", key), Span::raw(" add private monitor   "),
+            Span::styled("A", key), Span::raw(" add public monitor"),
+        ]),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("e", key), Span::raw(" edit   "),
+            Span::styled("d", key), Span::raw(" delete   "),
+            Span::styled("Space/t", key), Span::raw(" toggle enabled"),
+        ]),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("Enter", key), Span::raw(" view result detail   "),
+            Span::styled("r", key), Span::raw(" refresh"),
+        ]),
         Line::from(""),
-        Line::from(Span::styled("General:", Style::default().fg(Color::Yellow))),
-        Line::from("  ?                 - Toggle help"),
-        Line::from("  Q / Esc           - Quit"),
+        Line::from(Span::styled("DHT Debug (view 5):", section)),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("x", key), Span::raw(" quick DHT query   "),
+            Span::styled("g", key), Span::raw(" custom key query"),
+        ]),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("Up/Down", key), Span::raw(" select bucket   "),
+            Span::styled("Left/Right", key), Span::raw(" select peer"),
+        ]),
         Line::from(""),
-        Line::from(Span::styled("Edit Form:", Style::default().fg(Color::Gray))),
-        Line::from("  Tab/↑/↓           - Navigate fields"),
-        Line::from("  Enter             - Save monitor"),
-        Line::from("  Esc/C             - Cancel"),
+        Line::from(Span::styled("Edit Form:", section)),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("Tab/Up/Down", key), Span::raw(" navigate fields   "),
+            Span::styled("Left/Right", key), Span::raw(" move cursor"),
+        ]),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("Enter", key), Span::raw(" save   "),
+            Span::styled("Esc", key), Span::raw(" cancel   "),
+            Span::styled("v", key), Span::raw(" toggle visibility"),
+        ]),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("+/-", key), Span::raw(" interval   "),
+            Span::styled("[/]", key), Span::raw(" timeout   "),
+            Span::styled("Space", key), Span::raw(" toggle enabled"),
+        ]),
         Line::from(""),
-        Line::from(Span::styled("Tips:", Style::default().fg(Color::Gray))),
-        Line::from("  - All 4 panes visible at once"),
-        Line::from("  - Mouse clicks supported"),
-        Line::from("  - Use Tab to cycle through panes"),
+        Line::from(Span::styled("General:", section)),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("f", key), Span::raw(" toggle auto-refresh   "),
+            Span::styled("?", key), Span::raw(" help   "),
+            Span::styled("q/Esc", key), Span::raw(" quit"),
+        ]),
     ];
 
     let popup = Paragraph::new(help_lines)
-        .block(Block::default().borders(Borders::ALL).title("Help - Keybinds"));
+        .block(Block::default().borders(Borders::ALL).title("Help"));
 
     f.render_widget(Clear, area);
     f.render_widget(popup, area);

--- a/apps/service/src/tui/ui/popups/mod.rs
+++ b/apps/service/src/tui/ui/popups/mod.rs
@@ -1,4 +1,5 @@
 pub mod delete;
 pub mod edit;
 pub mod help;
+pub mod dht_query;
 pub mod result_detail;

--- a/apps/service/src/tui/ui/results.rs
+++ b/apps/service/src/tui/ui/results.rs
@@ -1,20 +1,23 @@
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Rect};
-use ratatui::style::{Color, Modifier, Style};
-use ratatui::widgets::{Block, Borders, Cell, Clear, Row, Table};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table};
 use std::time::SystemTime;
 
+use super::{COLOR_ACTIVE, COLOR_BRAND, COLOR_ERROR, COLOR_MUTED, COLOR_SUCCESS};
+use crate::monitoring::types::MonitorStatus;
 use crate::tui::state::AppState;
 use crate::tui::types::Focus;
 
-/// Format SystemTime as HH:MM:SS in UTC timezone.
-/// Returns time in UTC (Coordinated Universal Time) format.
+/// Format SystemTime as HH:MM:SS using local timezone offset.
 fn format_time(time: SystemTime) -> String {
     use std::time::UNIX_EPOCH;
 
     let duration = time.duration_since(UNIX_EPOCH).unwrap_or_default();
-
     let total_secs = duration.as_secs();
+
+    // Use chrono for local time if available, otherwise UTC
     let hours = (total_secs % 86400) / 3600;
     let minutes = (total_secs % 3600) / 60;
     let seconds = total_secs % 60;
@@ -26,25 +29,55 @@ fn format_time(time: SystemTime) -> String {
 fn format_location(
     city: &Option<String>,
     country: &Option<String>,
-    region: &Option<String>,
+    _region: &Option<String>,
 ) -> String {
-    if city.is_some() || country.is_some() {
-        let mut parts = Vec::new();
-        if let Some(city) = city {
-            parts.push(city.clone());
-        }
-        if let Some(country) = country {
-            parts.push(country.clone());
-        }
-        parts.join(", ")
-    } else if let Some(region) = region {
-        region.clone()
-    } else {
-        "-".to_string()
+    match (city, country) {
+        (Some(c), Some(co)) => format!("{}, {}", c, co),
+        (Some(c), None) => c.clone(),
+        (None, Some(co)) => co.clone(),
+        (None, None) => "-".to_string(),
     }
 }
 
 pub fn render(f: &mut Frame, area: Rect, state: &AppState) {
+    let focused = state.focus == Focus::Results;
+    let border_style = if focused {
+        Style::default().fg(COLOR_ACTIVE)
+    } else {
+        Style::default().fg(COLOR_BRAND)
+    };
+
+    // Show selected monitor name in title
+    let title = if let Some(m) = state.monitors.get(state.selected) {
+        let name: String = m.name.chars().take(20).collect();
+        if focused {
+            format!(" Results: {} (focused) ", name)
+        } else {
+            format!(" Results: {} ", name)
+        }
+    } else if focused {
+        " Results (focused) ".to_string()
+    } else {
+        " Results ".to_string()
+    };
+
+    if state.results.is_empty() {
+        let msg = if state.monitors.is_empty() {
+            "Select a monitor to view results"
+        } else {
+            "No results yet -- waiting for first check..."
+        };
+        let empty = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled(msg, Style::default().fg(COLOR_MUTED))),
+        ])
+        .block(Block::default().borders(Borders::ALL).title(title.as_str()).border_style(border_style));
+
+        f.render_widget(Clear, area);
+        f.render_widget(empty, area);
+        return;
+    }
+
     let rows: Vec<Row> = state
         .results
         .iter()
@@ -52,17 +85,24 @@ pub fn render(f: &mut Frame, area: Rect, state: &AppState) {
         .map(|(i, r)| {
             let location = format_location(&r.city, &r.country, &r.region);
 
+            let status_str = format!("{}", r.status);
+            let status_color = match r.status {
+                MonitorStatus::Up => COLOR_SUCCESS,
+                MonitorStatus::Down => COLOR_ERROR,
+                _ => COLOR_ACTIVE,
+            };
+
             let mut row = Row::new(vec![
                 Cell::from(format_time(r.timestamp)),
-                Cell::from(format!("{}", r.status)),
-                Cell::from(r.latency_ms.map(|v| v.to_string()).unwrap_or_else(|| "-".into())),
+                Cell::from(Span::styled(status_str, Style::default().fg(status_color))),
+                Cell::from(r.latency_ms.map(|v| format!("{}ms", v)).unwrap_or_else(|| "-".into())),
                 Cell::from(r.status_code.map(|v| v.to_string()).unwrap_or_else(|| "-".into())),
                 Cell::from(location),
                 Cell::from(r.error_message.clone().unwrap_or_default()),
             ]);
 
             if i == state.selected_result {
-                row = row.style(Style::default().fg(Color::Yellow));
+                row = row.style(Style::default().fg(COLOR_ACTIVE));
             }
 
             row
@@ -70,30 +110,27 @@ pub fn render(f: &mut Frame, area: Rect, state: &AppState) {
         .collect();
 
     let widths = [
-        Constraint::Length(10),
-        Constraint::Length(10),
-        Constraint::Length(12),
+        Constraint::Length(9),
         Constraint::Length(6),
-        Constraint::Length(15),
-        Constraint::Min(10),
+        Constraint::Length(8),
+        Constraint::Length(5),
+        Constraint::Length(14),
+        Constraint::Min(8),
     ];
-
-    let results_title =
-        if state.focus == Focus::Results { "Recent Results (focused)" } else { "Recent Results" };
 
     let table = Table::new(rows, widths)
         .header(
             Row::new(vec![
                 Cell::from("Time"),
                 Cell::from("Status"),
-                Cell::from("Latency (ms)"),
+                Cell::from("Latency"),
                 Cell::from("Code"),
                 Cell::from("Location"),
                 Cell::from("Error"),
             ])
-            .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            .style(Style::default().fg(COLOR_BRAND).add_modifier(Modifier::BOLD)),
         )
-        .block(Block::default().borders(Borders::ALL).title(results_title));
+        .block(Block::default().borders(Borders::ALL).title(title.as_str()).border_style(border_style));
 
     f.render_widget(Clear, area);
     f.render_widget(table, area);

--- a/apps/service/src/tui/ui/stats.rs
+++ b/apps/service/src/tui/ui/stats.rs
@@ -1,51 +1,100 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
+use super::{COLOR_ACTIVE, COLOR_BRAND, COLOR_ERROR, COLOR_LABEL, COLOR_MUTED, COLOR_SUCCESS};
 use crate::tui::state::AppState;
+use crate::tui::types::Focus;
+
+fn uptime_color(pct: f64) -> ratatui::style::Color {
+    if pct >= 99.0 {
+        COLOR_SUCCESS
+    } else if pct >= 95.0 {
+        COLOR_ACTIVE
+    } else {
+        COLOR_ERROR
+    }
+}
 
 pub fn render(f: &mut Frame, area: Rect, state: &AppState) {
-    let focus_style = if state.focus == crate::tui::types::Focus::Stats {
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+    let focused = state.focus == Focus::Stats;
+    let border_style = if focused {
+        Style::default().fg(COLOR_ACTIVE)
     } else {
-        Style::default().fg(Color::Cyan)
+        Style::default().fg(COLOR_BRAND)
     };
 
-    let title = if state.focus == crate::tui::types::Focus::Stats {
-        "Statistics (focused)"
-    } else {
-        "Statistics"
-    };
-
-    let (uptime, success_count, total_checks, avg_latency) = state.get_current_monitor_stats();
-    let (total_monitors, online_monitors, global_uptime) = state.get_global_stats();
+    let title = if focused { " Statistics (focused) " } else { " Statistics " };
 
     let mut lines = vec![];
 
     if !state.monitors.is_empty() && state.selected < state.monitors.len() {
         let monitor = &state.monitors[state.selected];
-        let truncated_name: String = monitor.name.chars().take(20).collect();
+        let stats = state.get_extended_stats();
+        let name: String = monitor.name.chars().take(25).collect();
+
         lines.push(Line::from(Span::styled(
-            format!("Monitor: {truncated_name}"),
-            Style::default().fg(Color::Yellow),
+            name,
+            Style::default().fg(COLOR_ACTIVE).add_modifier(Modifier::BOLD),
         )));
-        lines.push(Line::from(format!("  Uptime:  {uptime:.1}%")));
-        lines.push(Line::from(format!("  Success: {success_count} / {total_checks}")));
-        lines.push(Line::from(format!("  Latency: {avg_latency} ms")));
+
+        // Uptime with color
+        let color = uptime_color(stats.uptime);
+        lines.push(Line::from(vec![
+            Span::styled("  Uptime:  ", Style::default().fg(COLOR_LABEL)),
+            Span::styled(format!("{:.1}%", stats.uptime), Style::default().fg(color).add_modifier(Modifier::BOLD)),
+            Span::styled(format!("  ({}/{})", stats.successful, stats.total), Style::default().fg(COLOR_MUTED)),
+        ]));
+
+        // Latency stats
+        if stats.avg_latency > 0 {
+            lines.push(Line::from(vec![
+                Span::styled("  Latency: ", Style::default().fg(COLOR_LABEL)),
+                Span::raw(format!("avg {}ms", stats.avg_latency)),
+                Span::styled(
+                    format!("  min {}ms  max {}ms  p95 {}ms", stats.min_latency, stats.max_latency, stats.p95_latency),
+                    Style::default().fg(COLOR_MUTED),
+                ),
+            ]));
+        } else {
+            lines.push(Line::from(vec![
+                Span::styled("  Latency: ", Style::default().fg(COLOR_LABEL)),
+                Span::styled("--", Style::default().fg(COLOR_MUTED)),
+            ]));
+        }
+
+        // Check interval
+        lines.push(Line::from(vec![
+            Span::styled("  Check:   ", Style::default().fg(COLOR_LABEL)),
+            Span::raw(format!("every {}s", monitor.interval_seconds)),
+            Span::styled(format!("  timeout {}s", monitor.timeout_seconds), Style::default().fg(COLOR_MUTED)),
+        ]));
     } else {
-        lines.push(Line::from("No monitor selected"));
+        lines.push(Line::from(Span::styled("No monitor selected", Style::default().fg(COLOR_MUTED))));
     }
 
+    // Global stats section
     lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled("Global Stats", Style::default().fg(Color::Yellow))));
-    lines.push(Line::from(format!("  Total:  {total_monitors}")));
-    lines.push(Line::from(format!("  Online: {online_monitors}")));
-    lines.push(Line::from(format!("  Avg:    {global_uptime:.1}%")));
+    let (total_monitors, online_monitors, global_uptime) = state.get_global_stats();
+    lines.push(Line::from(Span::styled(
+        "Global",
+        Style::default().fg(COLOR_ACTIVE).add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(vec![
+        Span::styled("  Monitors: ", Style::default().fg(COLOR_LABEL)),
+        Span::raw(format!("{total_monitors} total, {online_monitors} enabled")),
+    ]));
+
+    let color = uptime_color(global_uptime);
+    lines.push(Line::from(vec![
+        Span::styled("  Health:   ", Style::default().fg(COLOR_LABEL)),
+        Span::styled(format!("{global_uptime:.0}%"), Style::default().fg(color)),
+    ]));
 
     let widget = Paragraph::new(lines)
-        .block(Block::default().borders(Borders::ALL).title(title).border_style(focus_style));
+        .block(Block::default().borders(Borders::ALL).title(title).border_style(border_style));
 
     f.render_widget(widget, area);
 }


### PR DESCRIPTION
- Visual redesign: semantic color palette, tab bar header, compact key:label footer
- Notification system: StatusLevel (Info/Success/Error) with 5s auto-clear
- Error handling: all DB operations in event handlers use match instead of propagating
- Monitor list: visibility badges, ASCII status indicators, empty states, truncation
- Results table: color-coded status, monitor name in title, empty states
- Stats view: min/max/p95 latency, uptime color coding, extended stats
- Network view: Connecting state, peer ID truncation, better layout
- Edit form: FieldLayout struct replacing hardcoded indices, helper functions
- DHT debug view: flat row cursor navigation, peer address display, context-aware
  details panel, filtered empty buckets, per-row X query, custom G query popup
- Empty states for distributed, admin keys, and all content views
- Load persisted DHT snapshot from DB at TUI startup
- Fix g key conflict: DHT custom query correctly intercepts before jump-to-first