### PR TITLE
Implement live settings, network, and status page API foundations

### DIFF
--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -1,0 +1,224 @@
+# AI Agent Guide
+
+This guide tells agents how to work in the Uppe repository.
+
+Read this first:
+
+- [ARCHITECTURE.md](/home/crunchy/dev/Obiente/Uppe/ARCHITECTURE.md)
+- [PROJECT_PLAN.md](/home/crunchy/dev/Obiente/Uppe/PROJECT_PLAN.md)
+- [PROJECT_AUDIT.md](/home/crunchy/dev/Obiente/Uppe/PROJECT_AUDIT.md)
+
+## What Uppe Is
+
+Uppe is a decentralized uptime monitoring platform with:
+
+- a Rust monitoring node in [apps/service](/home/crunchy/dev/Obiente/Uppe/apps/service)
+- a Go API/query layer in [apps/server](/home/crunchy/dev/Obiente/Uppe/apps/server)
+- an Astro frontend in [apps/client](/home/crunchy/dev/Obiente/Uppe/apps/client)
+- reusable P2P/replication infrastructure in [crates/peerup](/home/crunchy/dev/Obiente/Uppe/crates/peerup)
+
+Core product goals:
+
+- decentralized public monitoring
+- private/internal monitoring modes
+- resilient public status pages
+- signed audit/event history with peer verification
+
+## Ownership Rules
+
+These rules are not optional.
+
+### Rust owns
+
+- monitor execution
+- scheduling
+- local result creation
+- canonical signing/event generation
+- P2P runtime integration
+- replication behavior
+- trust verification
+- status-page bundle publication
+
+### Go owns
+
+- ConnectRPC APIs
+- CRUD/query workflows for UI-facing resources
+- aggregation/read models
+- audit query APIs
+- network/settings/status-page APIs
+
+### Astro owns
+
+- dashboard UX
+- monitor/settings/status-page management UX
+- public page rendering UX
+- audit inspection UX
+
+### PeerUP owns
+
+- transport
+- peer discovery
+- DHT/gossip/request-response primitives
+- generic replication mechanics
+
+## Sources of Truth
+
+### Database schema
+
+Canonical source:
+
+- [apps/service/src/database/migrations.rs](/home/crunchy/dev/Obiente/Uppe/apps/service/src/database/migrations.rs)
+
+Rule:
+
+- Rust migrations are the only executable schema source.
+
+Implications:
+
+- Go does not run migrations.
+- Obsolete Go migration files must not be treated as active truth.
+- [shared/database/schema.sql](/home/crunchy/dev/Obiente/Uppe/shared/database/schema.sql) is documentation, not the executable authority.
+
+### API contracts
+
+Canonical source:
+
+- [apps/server/proto](/home/crunchy/dev/Obiente/Uppe/apps/server/proto)
+
+Rule:
+
+- protobuf is the only API contract source.
+
+### Trust/audit events
+
+Canonical owner:
+
+- Rust trust/domain layer
+
+Rule:
+
+- trust-sensitive actions must be backed by canonical signed events
+
+## GitHub Project and Issue Workflow
+
+Roadmap issues live in:
+
+- milestone-backed GitHub issues
+- project board: `Uppe Roadmap`
+
+### Milestones
+
+Use these milestones:
+
+- `M1 Foundations`
+- `M2 Service Boundaries`
+- `M3 Status Pages MVP`
+- `M4 Trust and Audit`
+
+### Labels
+
+Use these labels consistently:
+
+- `roadmap`
+- `architecture`
+- `api`
+- `frontend`
+- `p2p`
+- `trust`
+- `status-pages`
+- `audit`
+- `backend`
+- `rust`
+- `go`
+- `astro`
+
+### Track field on the project board
+
+Use one of:
+
+- `Platform`
+- `Distributed Runtime`
+- `Trust and Audit`
+
+Suggested mapping:
+
+- schema/API/frontend integration work -> `Platform`
+- replication, peer networking, status-page bundle distribution -> `Distributed Runtime`
+- signature verification, trust chains, attestations, audit events -> `Trust and Audit`
+
+### How to work an issue
+
+1. Read the issue body and acceptance criteria.
+2. Check the milestone and labels.
+3. Confirm the work matches the ownership rules above.
+4. Update docs/contracts before or alongside code if the issue changes architecture.
+5. Keep implementation aligned with the roadmap rather than inventing parallel paths.
+
+### When opening new issues
+
+New issues should include:
+
+- summary
+- scope
+- why
+- deliverables
+- acceptance criteria
+
+Do not open vague TODO issues.
+
+## Rules for Agents
+
+### Do
+
+- keep Rust as the schema owner
+- keep protobuf as the API owner
+- reduce duplicate models
+- remove stale paths when they conflict with active architecture
+- prefer tightening boundaries before adding new features
+
+### Do not
+
+- add new executable schema definitions outside Rust migrations
+- add frontend pages that pretend a mock-only backend exists
+- leave placeholder verification in trust-critical paths
+- mix transport logic into monitoring/business logic unnecessarily
+- create new "source of truth" documents that contradict the architecture docs
+
+## Current Execution Order
+
+Work should generally follow this sequence:
+
+1. foundations
+2. schema/API cleanup
+3. service boundary cleanup
+4. trust hardening
+5. status-page bundle MVP
+6. network/settings API completion
+7. audit and attestation system
+
+## Immediate Priority
+
+The first implementation priority is:
+
+- make Rust migrations the only active DB schema source
+
+That includes:
+
+- removing or deprecating obsolete Go migration paths
+- fixing docs that still imply Go runs migrations
+- keeping shared schema docs clearly documented as non-authoritative
+
+## File References
+
+Core docs:
+
+- [ARCHITECTURE.md](/home/crunchy/dev/Obiente/Uppe/ARCHITECTURE.md)
+- [PROJECT_PLAN.md](/home/crunchy/dev/Obiente/Uppe/PROJECT_PLAN.md)
+- [PROJECT_AUDIT.md](/home/crunchy/dev/Obiente/Uppe/PROJECT_AUDIT.md)
+
+Core code:
+
+- [apps/service/src/database/migrations.rs](/home/crunchy/dev/Obiente/Uppe/apps/service/src/database/migrations.rs)
+- [apps/server/internal/db/libsql/libsql.go](/home/crunchy/dev/Obiente/Uppe/apps/server/internal/db/libsql/libsql.go)
+- [apps/server/proto](/home/crunchy/dev/Obiente/Uppe/apps/server/proto)
+- [crates/peerup](/home/crunchy/dev/Obiente/Uppe/crates/peerup)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,358 @@
+# Uppe Architecture
+
+Date: 2026-04-04
+
+## Purpose
+
+This document freezes the intended ownership boundaries for Uppe so future implementation work has a stable target.
+
+It is the root architecture reference for:
+
+- runtime ownership
+- database schema ownership
+- RPC/API ownership
+- frontend ownership
+- P2P ownership
+- trust and audit ownership
+
+This document should be read together with:
+
+- [PROJECT_PLAN.md](/home/crunchy/dev/Obiente/Uppe/PROJECT_PLAN.md)
+- [PROJECT_AUDIT.md](/home/crunchy/dev/Obiente/Uppe/PROJECT_AUDIT.md)
+
+## System Overview
+
+Uppe is a decentralized monitoring platform made of four major systems:
+
+1. Rust monitoring node
+2. Go API/query layer
+3. Astro frontend
+4. Peer verification, replication, and audit network
+
+Those systems must cooperate, but they must not overlap in responsibility.
+
+## Ownership Boundaries
+
+## Rust Service
+
+Location:
+
+- [apps/service](/home/crunchy/dev/Obiente/Uppe/apps/service)
+
+Rust owns:
+
+- monitor execution
+- scheduling
+- local result creation
+- key management
+- canonical event creation and signing
+- P2P runtime integration
+- replication behavior
+- trust verification
+- status-page bundle publication
+
+Rust does not own:
+
+- browser-facing query APIs
+- frontend rendering
+- ad hoc CRUD workflows meant only for UI consumption
+
+## Go API
+
+Location:
+
+- [apps/server](/home/crunchy/dev/Obiente/Uppe/apps/server)
+
+Go owns:
+
+- RPC/query APIs for the frontend and external clients
+- CRUD APIs for monitors, status pages, and settings
+- aggregation and read models
+- query-oriented access to audit and network state
+
+Go does not own:
+
+- database migrations
+- monitoring execution
+- peer networking
+- trust source-of-truth decisions
+
+## Astro Frontend
+
+Location:
+
+- [apps/client](/home/crunchy/dev/Obiente/Uppe/apps/client)
+
+Astro owns:
+
+- operator dashboard UX
+- monitor management UX
+- analytics UX
+- status-page management UX
+- public status-page rendering UX
+- audit inspection UX
+
+Astro does not own:
+
+- long-lived business state
+- handwritten API contract truth
+- trust verification logic
+
+## PeerUP
+
+Location:
+
+- [crates/peerup](/home/crunchy/dev/Obiente/Uppe/crates/peerup)
+
+PeerUP owns reusable infrastructure for:
+
+- peer discovery
+- gossip topics
+- DHT operations
+- transport behavior
+- generic replication primitives
+- peer verification message transport
+
+PeerUP does not own Uppe-specific dashboard or CRUD rules.
+
+## Sources of Truth
+
+## Database Schema
+
+Canonical source:
+
+- Rust migrations in [apps/service/src/database/migrations.rs](/home/crunchy/dev/Obiente/Uppe/apps/service/src/database/migrations.rs)
+
+Rule:
+
+- Rust migrations are the only executable database schema source.
+
+Implications:
+
+- Go must adapt to the schema created by Rust.
+- shared schema docs must be generated from Rust-owned migration state or treated as documentation only.
+- obsolete migration files outside Rust must not remain active sources of truth.
+
+## RPC/API Contracts
+
+Canonical source:
+
+- protobuf definitions in [apps/server/proto](/home/crunchy/dev/Obiente/Uppe/apps/server/proto)
+
+Rule:
+
+- Protobuf is the only API contract source.
+
+Implications:
+
+- Go service implementations must match active protos.
+- Astro uses generated TS clients and types.
+- handwritten parallel API DTOs should be minimized.
+
+## Signed Event Format
+
+Canonical owner:
+
+- Rust service domain/trust layer
+
+Rule:
+
+- Uppe uses a canonical signed event envelope for trust-sensitive actions.
+
+This envelope will back:
+
+- monitor changes
+- monitoring results
+- peer attestations
+- status-page publish events
+- audit records
+- trust-chain updates
+
+## Runtime Architecture
+
+## Monitoring Runtime
+
+The monitoring runtime is responsible for:
+
+- scheduling checks
+- running checkers
+- generating local results
+- writing local results
+
+It should not know transport details.
+
+## P2P Runtime
+
+The P2P runtime is responsible for:
+
+- joining the network
+- discovering peers
+- publishing and receiving protocol messages
+- replication transport
+- DHT fetch/store behavior
+
+It should not decide product semantics by itself.
+
+## Trust Runtime
+
+The trust runtime is responsible for:
+
+- signing
+- signature verification
+- attestation verification
+- trust-chain validation
+- audit integrity checks
+
+It should be isolated from frontend or query concerns.
+
+## Orchestration Layer
+
+The orchestration layer composes:
+
+- monitoring runtime
+- P2P runtime
+- trust runtime
+- storage
+
+It is allowed to coordinate, but not to become the home for all business logic indefinitely.
+
+## Domain Model
+
+## Monitors
+
+Monitor visibility modes:
+
+- Public
+- Private
+- Internal
+
+Rules:
+
+- Public monitors participate in network coordination.
+- Private monitors allow assisted workflows with privacy guarantees.
+- Internal monitors never leave the owner node.
+
+## Results
+
+Result classes:
+
+- local results
+- peer results
+- verification attestations
+- derived aggregations
+
+Rules:
+
+- raw results are immutable evidence
+- verification is an additional record, not an in-place mutation of truth
+
+## Status Pages
+
+Status pages have two layers:
+
+1. Authoring layer
+- page identity
+- branding
+- monitor bindings
+- publication state
+
+2. Published bundle layer
+- immutable signed bundle
+- page assets
+- summary snapshot
+- replication metadata
+
+## Audit
+
+Audit is a first-class system, not a log appendix.
+
+Audit tracks:
+
+- what happened
+- who signed it
+- who verified it
+- where it replicated
+- whether it met verification thresholds
+
+## Public Status Page Hosting Model
+
+The intended hosting model is:
+
+1. Owner publishes a signed status-page bundle.
+2. Peers replicate the bundle and recent signed summary data.
+3. A browser-compatible gateway serves the bundle even if the owner node is offline.
+4. Custom domains map to the gateway/resolver layer.
+
+This means early resilient hosting is gateway-backed, network-replicated hosting.
+
+It is explicitly not:
+
+- arbitrary peer-hosted dynamic frontend execution
+- browser-native libp2p page hosting as the first milestone
+
+## Interface Boundaries
+
+## Rust -> Go
+
+Primary interface:
+
+- shared database state
+- optional future internal contracts only when necessary
+
+Rule:
+
+- Go reads and mutates user-facing state, but does not become the execution engine.
+
+## Go -> Astro
+
+Primary interface:
+
+- ConnectRPC/protobuf-generated contracts
+
+Rule:
+
+- Astro should not reach into DB assumptions directly.
+
+## Rust -> PeerUP
+
+Primary interface:
+
+- explicit transport/replication abstractions
+
+Rule:
+
+- Uppe domain code should depend on protocol boundaries, not raw libp2p behavior whenever possible.
+
+## Immediate Rules for Ongoing Work
+
+1. No new schema source may be introduced outside Rust migrations.
+2. No new API surface should be documented as active unless it is implemented or clearly marked experimental.
+3. No trust-critical placeholder verification may remain in paths that claim production trust guarantees.
+4. No new major frontend page should ship as if complete while its backend is still mock-only.
+5. New work should attach to one of these workstreams:
+- Platform
+- Distributed Runtime
+- Trust and Audit
+
+## Near-Term Architecture Deliverables
+
+1. Remove schema drift between Rust, shared docs, and old Go migration files.
+2. Align active proto services with actual Go implementations.
+3. Split Rust service responsibilities into clearer domain/runtime modules.
+4. Define the canonical signed event envelope.
+5. Implement status-page bundles and replicated gateway serving.
+6. Implement audit events and peer attestations.
+
+## Decision Summary
+
+The final architecture direction is:
+
+- Rust executes and signs
+- Go serves and aggregates
+- Astro renders and manages UX
+- PeerUP transports and replicates
+- Rust migrations define the database
+- protobuf defines the API
+- signed events define trust and audit
+
+Any implementation that crosses those boundaries needs explicit justification.

--- a/PROJECT_AUDIT.md
+++ b/PROJECT_AUDIT.md
@@ -1,0 +1,381 @@
+# Uppe Project Audit
+
+Date: 2026-04-04
+
+## Executive Summary
+
+Uppe is a decentralized uptime monitoring platform built around a Rust service that performs checks, stores results locally, and participates in a libp2p-based peer network. A Go API server exposes monitoring data over ConnectRPC for a frontend dashboard built in Astro/TypeScript.
+
+The project direction is coherent, but the implementation is in a transitional state:
+
+- The Rust service is the most complete part and compiles successfully.
+- The Go API server compiles and `go test ./...` passes, but it only implements monitor/result services.
+- The frontend has real integration for core monitor/result views, but several pages and services are still placeholders or mock-backed.
+- The codebase has architectural drift around schema ownership, API surface area, and frontend messaging about P2P readiness.
+
+## Verified State
+
+- `cargo check -p uppe-service`: passes
+- `go test ./...` in `apps/server`: passes
+- Frontend runtime/tests were not fully verified in this shell because Node is not available on the Linux path even though `pnpm` resolves.
+
+## What The Project Is
+
+Uppe is intended to be a peer-to-peer uptime monitoring system:
+
+- Users create monitors for HTTP, TCP, and eventually ICMP targets.
+- The Rust service executes checks on schedule and stores results in a shared SQLite/LibSQL database.
+- Results can be signed and shared across peers through the PeerUP/libp2p layer.
+- The Go server reads from the shared database and exposes API endpoints for dashboards and other clients.
+- The Astro frontend renders dashboards, analytics, service detail pages, network views, settings, and public status pages.
+
+## How It Works Today
+
+### 1. Core runtime
+
+- The main runtime entrypoint is [`apps/service/src/main.rs`](/home/crunchy/dev/Obiente/Uppe/apps/service/src/main.rs).
+- The service loads config, initializes the shared LibSQL database, loads a keypair, sets up location tracking, and starts the orchestrator.
+- The orchestrator in [`apps/service/src/orchestrator/mod.rs`](/home/crunchy/dev/Obiente/Uppe/apps/service/src/orchestrator/mod.rs) coordinates monitoring, database writes, P2P startup, helper assignment logic, and retention cleanup.
+
+### 2. Monitoring flow
+
+- Monitor definitions live in the `monitors` table.
+- Scheduled checks produce `monitor_results`.
+- Peer-received results are stored separately in `peer_results`.
+- The monitoring engine currently supports HTTP/HTTPS and TCP. ICMP is still a stub in [`apps/service/src/monitoring/checker.rs#L88`](/home/crunchy/dev/Obiente/Uppe/apps/service/src/monitoring/checker.rs#L88).
+
+### 3. API layer
+
+- The Go server entrypoint is [`apps/server/cmd/server/main.go`](/home/crunchy/dev/Obiente/Uppe/apps/server/cmd/server/main.go).
+- The server registers only `MonitorService` and `ResultService` in [`apps/server/internal/server/server.go#L66`](/home/crunchy/dev/Obiente/Uppe/apps/server/internal/server/server.go#L66).
+- The monitor and result services read from the shared database and expose ConnectRPC endpoints used by the client dashboard.
+
+### 4. Frontend
+
+- The frontend uses generated Connect clients in [`apps/client/src/lib/api/client.ts`](/home/crunchy/dev/Obiente/Uppe/apps/client/src/lib/api/client.ts).
+- Dashboard and analytics pages pull real monitor/result data from the Go API.
+- Several other areas are still static or mock-backed: settings, network map, public status pages, and status-page management.
+
+## High-Priority Findings
+
+### 1. Competing database schemas and multiple "sources of truth"
+
+Severity: High
+
+The repo currently has at least three schema definitions that do not agree:
+
+- Rust migration source in [`apps/service/src/database/migrations.rs#L7`](/home/crunchy/dev/Obiente/Uppe/apps/service/src/database/migrations.rs#L7)
+- Shared schema doc in [`shared/database/schema.sql#L1`](/home/crunchy/dev/Obiente/Uppe/shared/database/schema.sql#L1)
+- Old Go migration file in [`apps/server/internal/db/migrations/001_initial_schema.sql#L1`](/home/crunchy/dev/Obiente/Uppe/apps/server/internal/db/migrations/001_initial_schema.sql#L1)
+
+Examples of drift:
+
+- Shared schema says `monitors.id` is `INTEGER PRIMARY KEY AUTOINCREMENT` in [`shared/database/schema.sql#L24`](/home/crunchy/dev/Obiente/Uppe/shared/database/schema.sql#L24).
+- Old Go migration says `monitors.id` is `TEXT PRIMARY KEY` and uses `url`/`type` columns in [`apps/server/internal/db/migrations/001_initial_schema.sql#L6`](/home/crunchy/dev/Obiente/Uppe/apps/server/internal/db/migrations/001_initial_schema.sql#L6).
+- Rust migrations actually create `target`/`check_type` and append newer orchestration fields in [`apps/service/src/database/migrations.rs#L97`](/home/crunchy/dev/Obiente/Uppe/apps/service/src/database/migrations.rs#L97).
+
+Impact:
+
+- This is the biggest architecture risk in the repo.
+- New contributors can follow the wrong schema.
+- Any future non-Rust migration work can silently break compatibility.
+
+Recommendation:
+
+- Make Rust migrations the only executable schema source.
+- Mark the old Go migration directory as obsolete or remove it.
+- Generate `shared/database/schema.sql` from the Rust schema, or delete it if it cannot be kept authoritative.
+
+### 2. The Go server exposes only part of the declared API surface
+
+Severity: High
+
+The proto layer defines `NetworkService`, `SettingsService`, and `StatusPageService`:
+
+- [`apps/server/proto/network/v1/network.proto#L9`](/home/crunchy/dev/Obiente/Uppe/apps/server/proto/network/v1/network.proto#L9)
+- [`apps/server/proto/settings/v1/settings.proto#L7`](/home/crunchy/dev/Obiente/Uppe/apps/server/proto/settings/v1/settings.proto#L7)
+- [`apps/server/proto/statuspage/v1/statuspage.proto#L9`](/home/crunchy/dev/Obiente/Uppe/apps/server/proto/statuspage/v1/statuspage.proto#L9)
+
+But the server registers only monitor/result handlers in [`apps/server/internal/server/server.go#L66-L75`](/home/crunchy/dev/Obiente/Uppe/apps/server/internal/server/server.go#L66-L75), and there are no implementations for those additional services.
+
+Impact:
+
+- The API contract implies more capability than the backend actually provides.
+- Frontend and docs can drift ahead of reality.
+
+Recommendation:
+
+- Either implement and register these services next, or remove/defer the protos until the backend contract is real.
+
+### 3. Frontend product claims do not match backend reality
+
+Severity: High
+
+Core examples:
+
+- Network map page says P2P is "coming soon" and uses generated fake node data in [`apps/client/src/pages/network-map.astro#L25-L45`](/home/crunchy/dev/Obiente/Uppe/apps/client/src/pages/network-map.astro#L25-L45), even though the Rust service already contains substantial P2P code.
+- Settings page is entirely local defaults and not wired to any settings backend in [`apps/client/src/pages/settings.astro#L24-L53`](/home/crunchy/dev/Obiente/Uppe/apps/client/src/pages/settings.astro#L24-L53).
+- Public status page route is static/mock content in [`apps/client/src/pages/public/[slug].astro#L18-L77`](/home/crunchy/dev/Obiente/Uppe/apps/client/src/pages/public/[slug].astro#L18-L77).
+- Status page service is still returning fabricated data in [`apps/client/src/lib/services/statusPageService.ts#L67-L287`](/home/crunchy/dev/Obiente/Uppe/apps/client/src/lib/services/statusPageService.ts#L67-L287).
+
+Impact:
+
+- The system message to users is inconsistent.
+- The frontend currently overstates readiness in some docs and understates it in some pages.
+
+Recommendation:
+
+- Decide the product truth for this phase:
+  - Either "P2P core exists, UI is incomplete"
+  - Or "P2P is experimental, not user-ready"
+- Then align pages, docs, and API surfacing to that one statement.
+
+### 4. Signature verification is still bypassed in critical trust paths
+
+Severity: High
+
+Examples:
+
+- PeerUP distributed data verification returns `true` unconditionally in [`crates/peerup/src/distributed/messages.rs#L100-L105`](/home/crunchy/dev/Obiente/Uppe/crates/peerup/src/distributed/messages.rs#L100-L105).
+- Admin trust-chain verification uses `signature.len() == 64` as a placeholder in [`apps/service/src/orchestrator/admin_trust.rs#L113-L167`](/home/crunchy/dev/Obiente/Uppe/apps/service/src/orchestrator/admin_trust.rs#L113-L167).
+
+Impact:
+
+- The decentralized trust model is not yet enforceable.
+- Architectural claims around signed results and key-chain validation are only partially true.
+
+Recommendation:
+
+- Treat this as a security milestone, not a cleanup task.
+- Implement real canonical-message signing and verification before expanding network-facing features.
+
+## Medium-Priority Findings
+
+### 5. `NewDatabase` can panic on short database paths
+
+Severity: Medium
+
+In [`apps/server/internal/db/factory.go#L21`](/home/crunchy/dev/Obiente/Uppe/apps/server/internal/db/factory.go#L21), the code slices `databaseURL[:7]` and `databaseURL[:8]` without guarding length first.
+
+Impact:
+
+- A short path like `a.db` can panic before the server returns a configuration error.
+
+Recommendation:
+
+- Replace manual slicing with `strings.HasPrefix`.
+
+### 6. CORS handling is unsafe and invalid for credentialed requests
+
+Severity: Medium
+
+[`apps/server/internal/server/server.go#L27-L39`](/home/crunchy/dev/Obiente/Uppe/apps/server/internal/server/server.go#L27-L39) reflects arbitrary origins and also sets `Access-Control-Allow-Credentials: true`. It also falls back to `*`.
+
+Impact:
+
+- `*` with credentials is invalid.
+- Reflecting arbitrary origins is not a real production CORS policy.
+
+Recommendation:
+
+- Add an allowlist from config.
+- Disable credentials unless there is a specific authenticated browser flow requiring them.
+
+### 7. Go model layer is duplicated and internally inconsistent
+
+Severity: Medium
+
+There are at least three overlapping model representations:
+
+- Business model in [`apps/server/internal/models/monitor.go`](/home/crunchy/dev/Obiente/Uppe/apps/server/internal/models/monitor.go)
+- "Shared schema" DB model in [`apps/server/internal/models/shared_schema.go`](/home/crunchy/dev/Obiente/Uppe/apps/server/internal/models/shared_schema.go)
+- Older GORM model in [`apps/server/internal/models/monitor_gorm.go`](/home/crunchy/dev/Obiente/Uppe/apps/server/internal/models/monitor_gorm.go)
+
+These disagree on:
+
+- `id` type
+- whether `uuid` and `id` are the same
+- whether the DB uses `target` vs `url`
+- whether visibility fields are included
+
+Impact:
+
+- This raises maintenance cost and schema confusion.
+- The current code compiles, but future changes are likely to update the wrong model.
+
+Recommendation:
+
+- Collapse onto one DB model layer and one business model layer.
+- Remove `monitor_gorm.go` if `shared_schema.go` is the real path forward.
+
+### 8. Settings page hardcodes the wrong API port
+
+Severity: Medium
+
+[`apps/client/src/pages/settings.astro#L86-L89`](/home/crunchy/dev/Obiente/Uppe/apps/client/src/pages/settings.astro#L86-L89) displays `http://localhost:8081`, while the actual default API base is `http://localhost:8080` in [`apps/client/src/lib/api/client.ts#L12`](/home/crunchy/dev/Obiente/Uppe/apps/client/src/lib/api/client.ts#L12) and the Go server default is port 8080 in [`apps/server/internal/config/config.go`](/home/crunchy/dev/Obiente/Uppe/apps/server/internal/config/config.go).
+
+Impact:
+
+- This is a user-visible correctness bug.
+
+Recommendation:
+
+- Drive displayed endpoint information from the same config/env source the client uses.
+
+### 9. ICMP is exposed as a monitor type but is not implemented
+
+Severity: Medium
+
+The system still exposes ICMP as a real monitor type in multiple places, but the checker explicitly returns an error in [`apps/service/src/monitoring/checker.rs#L88-L109`](/home/crunchy/dev/Obiente/Uppe/apps/service/src/monitoring/checker.rs#L88-L109).
+
+Impact:
+
+- Users can think ping monitoring exists when it does not.
+
+Recommendation:
+
+- Either remove ICMP from user-facing creation flows for now or mark it as experimental/disabled in UI and API.
+
+## Lower-Priority / Structural Findings
+
+### 10. Repo hygiene needs tightening
+
+Observed artifacts include:
+
+- Local databases under `shared/data/`
+- Multiple keypair files under `apps/service/*.key`
+- Generated Astro workspace artifacts in `apps/client/.astro/`
+
+Some are ignored, but keypair files are currently present in the worktree and should not live as normal project assets.
+
+Recommendation:
+
+- Ignore generated keypair files and local dev databases consistently.
+- Keep sample fixtures distinct from real runtime credentials.
+
+### 11. Frontend docs are inconsistent
+
+- [`apps/client/README.md`](/home/crunchy/dev/Obiente/Uppe/apps/client/README.md) is still the Astro starter README.
+- Other client docs claim production readiness or real-data integration.
+
+Recommendation:
+
+- Replace the starter README with an accurate frontend overview.
+
+### 12. There is little automated test coverage around the riskiest logic
+
+What was verified:
+
+- Go packages compile and tests pass, but there are effectively no substantive tests there.
+- Rust service compiles.
+
+What is still weak:
+
+- No meaningful audit-proof tests for schema compatibility.
+- No strong end-to-end tests for Rust service + Go API + shared DB.
+- No security tests around signature verification or trust-chain logic.
+
+## Unimplemented Features
+
+### Backend/API
+
+- `NetworkService`: proto exists, server implementation absent.
+- `SettingsService`: proto exists, server implementation absent.
+- `StatusPageService`: proto exists, server implementation absent.
+- `ResultService.StreamResults`: explicit TODO in [`apps/server/internal/connect/result/result.go#L100-L113`](/home/crunchy/dev/Obiente/Uppe/apps/server/internal/connect/result/result.go#L100-L113).
+- PostgreSQL/TimescaleDB support: explicitly unimplemented in [`apps/server/internal/db/factory.go#L27-L29`](/home/crunchy/dev/Obiente/Uppe/apps/server/internal/db/factory.go#L27-L29).
+
+### Rust service
+
+- Real ICMP monitoring.
+- Real admin-trust signature verification.
+- Full DHT-backed admin key caching/rotation completion.
+- Some retention/orchestration paths remain placeholders.
+
+### Frontend
+
+- Real settings integration.
+- Real network map integration.
+- Real public status pages.
+- Real status-page CRUD and publish flow.
+- Incidents and alerting are still not backed end-to-end.
+
+## Structure Assessment
+
+## What is structured well
+
+- The top-level split is sensible:
+  - `apps/service` for the runtime node
+  - `apps/server` for API
+  - `apps/client` for UI
+  - `crates/peerup` for reusable P2P logic
+- The service/orchestrator boundary is reasonable.
+- The Go API reading a shared DB instead of controlling the monitoring engine is the right separation.
+
+## What is not structured well enough yet
+
+- Schema authority is not singular in practice.
+- The Go model layer is duplicated.
+- Product surface is defined in more places than implementation exists.
+- The frontend includes multiple "future" feature surfaces as if they were near-complete, while the backend contracts for those features are still mostly declarative.
+
+## Recommended Next Steps
+
+### Phase 1: Stabilize the architecture
+
+1. Make Rust migrations the only schema source of truth.
+2. Remove or clearly archive obsolete Go migration/schema files.
+3. Consolidate Go DB/business models into one path.
+4. Replace the Astro starter README and align all docs with actual feature status.
+
+### Phase 2: Close correctness/security gaps
+
+1. Fix the database path prefix panic in `apps/server/internal/db/factory.go`.
+2. Replace permissive CORS reflection with configured origins.
+3. Implement real signature verification for:
+   - peer data
+   - admin key rotations
+   - revocation lists
+4. Hide or disable ICMP until it actually works.
+
+### Phase 3: Finish the missing API surface
+
+1. Implement `SettingsService`.
+2. Implement `NetworkService`.
+3. Implement `StatusPageService`.
+4. Decide whether `StreamResults` is actually required now; if not, remove it from the short-term contract.
+
+### Phase 4: Bring the frontend back in sync
+
+1. Replace placeholder settings page with live API-backed values.
+2. Replace the network map placeholder with real peer/network stats or remove the page from nav until it exists.
+3. Replace mock public status pages with backend-backed content.
+4. Remove any remaining mock utility modules that are no longer part of the intended runtime path.
+
+### Phase 5: Add integration confidence
+
+1. Add an integration test that boots:
+   - Rust service migrations
+   - Go API
+   - shared DB assertions
+2. Add contract tests for schema compatibility.
+3. Add end-to-end frontend smoke tests for:
+   - dashboard
+   - analytics
+   - monitor CRUD
+
+## Bottom Line
+
+The project is not off-plan conceptually. The intended architecture is still sound:
+
+- Rust node as the source of monitoring and P2P truth
+- Go API as a read/write presentation layer
+- Astro frontend as a dashboard and public UI
+
+Where it is drifting is execution discipline:
+
+- too many parallel "source of truth" files
+- too many declared APIs without implementations
+- too many placeholder UIs presented alongside real features
+
+If the next work focuses on consolidation before expansion, the architecture can still hold cleanly. If new features keep landing before the schema/API/documentation layers are unified, the project will become much harder to evolve safely.

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -1,0 +1,664 @@
+# Uppe Project Plan
+
+Date: 2026-04-04
+
+## Goal
+
+Turn Uppe into a coherent decentralized monitoring platform with:
+
+- a reliable Rust monitoring node
+- a clean Go API/query layer
+- a typed Astro frontend
+- resilient public status pages that can survive owner node downtime
+- signed audit/event records replicated and verified across peers
+
+This plan assumes the current direction remains:
+
+- Rust is the execution runtime
+- Go is the API/query layer
+- Astro is the operator/public UI
+- PeerUP is the reusable P2P and replication layer
+
+## Product Vision
+
+Uppe should eventually support three major user experiences:
+
+1. Self-hosted monitoring node
+- A user runs a node, creates monitors, sees results, and optionally joins the network.
+
+2. Public decentralized monitoring
+- Public monitors are redundantly checked by multiple peers.
+- Results are signed and verifiable.
+
+3. Public status pages with network-backed availability
+- A user publishes a status page.
+- The page remains available even if the owner's node is offline.
+- The owner can point a custom domain at the page without self-hosting the full frontend.
+
+## Architecture Principles
+
+### 1. Single ownership per concern
+
+- Rust owns execution, peer protocols, signing, and replication.
+- Go owns user-facing APIs, aggregation, and query/mutation workflows.
+- Astro owns rendering and UX only.
+
+### 2. One source of truth per contract
+
+- Database schema: Rust migrations only.
+- RPC/API schema: protobuf only.
+- Frontend generated types: generated from protobuf, not duplicated manually.
+
+### 3. Event-first trust model
+
+- Important actions become signed events.
+- Events are append-only.
+- Replication and verification happen at the event level.
+- UI and APIs query materialized state derived from signed events plus local indexes.
+
+### 4. P2P and application logic stay separate
+
+- P2P transport is not business logic.
+- Monitoring logic does not know transport details.
+- Trust verification is not mixed into UI-facing handlers.
+
+## Target System Layout
+
+## Rust Service Responsibilities
+
+The Rust service should own:
+
+- monitor scheduling and execution
+- local persistence
+- key management
+- canonical event creation and signing
+- peer discovery
+- result replication
+- audit replication
+- trust verification
+- status-page bundle publication to the network
+
+Recommended internal split:
+
+- `domain/monitors`
+- `domain/results`
+- `domain/status_pages`
+- `domain/audit`
+- `runtime/monitoring`
+- `runtime/p2p`
+- `runtime/trust`
+- `runtime/orchestration`
+- `storage/sqlite`
+
+## Go API Responsibilities
+
+The Go server should own:
+
+- monitor CRUD APIs
+- result query APIs
+- network stats query APIs
+- settings APIs
+- status page CRUD/query APIs
+- audit query APIs
+- materialized read models built from shared DB state
+
+It should not own:
+
+- migrations
+- peer networking
+- cryptographic source-of-truth decisions
+- background monitoring execution
+
+## Astro Frontend Responsibilities
+
+The Astro frontend should own:
+
+- operator dashboard
+- monitor creation/edit flows
+- analytics views
+- settings views
+- status-page management UX
+- public status-page rendering
+- audit inspection UI
+
+It should not invent business state locally except for temporary form state.
+
+## PeerUP Responsibilities
+
+PeerUP should be the reusable infrastructure layer for:
+
+- peer discovery
+- gossipsub topics
+- DHT operations
+- content replication
+- replication acknowledgements
+- peer verification messages
+
+It should not know Uppe-specific dashboard or CRUD semantics.
+
+## Canonical Contracts
+
+## 1. Database Schema
+
+Decision:
+
+- Rust migrations are the only executable schema source.
+
+Rules:
+
+- `apps/service/src/database/migrations.rs` is authoritative.
+- `shared/database/schema.sql` becomes generated documentation, not hand-maintained truth.
+- old Go migration files are archived or removed from active use.
+
+Required work:
+
+1. Remove schema drift.
+2. Add a script that emits schema docs from the Rust migration state.
+3. Add CI that fails if shared schema docs drift from the Rust migration output.
+
+## 2. RPC/API Schema
+
+Decision:
+
+- Protobuf is the only API contract source.
+
+Rules:
+
+- Go service implementations must match registered proto services exactly.
+- Astro clients must use generated TS clients/types.
+- avoid parallel handwritten API DTOs unless they are UI-only view models
+
+Required work:
+
+1. Keep only the services that are actually supported, or implement the missing ones.
+2. Add contract tests for generated clients against a live Go server.
+
+## 3. Event Schema
+
+Decision:
+
+- Uppe needs a canonical signed event envelope.
+
+Proposed envelope fields:
+
+- `event_id`
+- `event_type`
+- `version`
+- `timestamp`
+- `source_peer_id`
+- `subject_id`
+- `payload`
+- `payload_hash`
+- `signature`
+- `public_key`
+- `previous_event_hash` optional
+
+This envelope will back:
+
+- monitor mutations
+- monitoring results
+- peer verification attestations
+- status page revisions
+- audit records
+- admin trust updates
+
+## Domain Design
+
+## 1. Monitors
+
+Subtypes:
+
+- public monitors
+- private monitors
+- internal monitors
+
+Rules:
+
+- Public monitors participate in shared coordination.
+- Private monitors allow peer-assisted encrypted workflows.
+- Internal monitors never leave the owner node.
+
+Needed output:
+
+- one clean domain model
+- one persistence model
+- one API representation
+
+## 2. Results
+
+Results should be split conceptually:
+
+- local check results
+- peer-received results
+- verification attestations
+- aggregated read models
+
+Rules:
+
+- raw signed results are immutable
+- verification is a separate attestation, not an in-place mutation of trust
+
+## 3. Status Pages
+
+Status pages need two layers:
+
+1. Authoring layer
+- owner defines title, slug, branding, linked monitors, visibility
+
+2. Published bundle layer
+- deterministic signed page manifest
+- assets
+- latest signed summary snapshot
+- optional recent incidents summary
+
+Status pages should be renderable without needing the owner node online.
+
+## 4. Audit
+
+Audit must not be an afterthought. It should be a first-class append-only record system.
+
+Core concepts:
+
+- signed event
+- peer attestation
+- replication proof
+- query index
+
+Audit queries should answer:
+
+- what happened
+- who claimed it
+- who verified it
+- what evidence exists
+- whether quorum was met
+
+## Public Status Pages: Resilient Hosting Plan
+
+## Problem
+
+Users want public monitor pages on their own domain without having to keep their own node online. The network should preserve availability.
+
+## Practical Design
+
+Do not start with "browser-native P2P hosting". Browsers and DNS constraints make that the wrong first milestone.
+
+Use a layered design:
+
+### Layer 1: Signed page bundle
+
+Each published status page becomes a signed immutable bundle:
+
+- manifest
+- branding metadata
+- monitor bindings
+- rendered assets
+- current signed status summary
+
+Bundle fields:
+
+- `bundle_id`
+- `owner_peer_id`
+- `status_page_id`
+- `revision`
+- `content_hash`
+- `created_at`
+- `signature`
+
+### Layer 2: Replication across peers
+
+Peers store and serve:
+
+- page manifest
+- immutable assets
+- recent signed summaries
+
+This is content replication, not arbitrary app hosting.
+
+### Layer 3: Gateway serving
+
+Gateways serve content by:
+
+- content hash
+- page slug
+- owner mapping
+
+This gives browser compatibility immediately.
+
+### Layer 4: Custom domain mapping
+
+Users point DNS to an Uppe gateway/resolver.
+
+Options:
+
+- `CNAME status.example.com -> gateway.uppe.dev`
+- TXT-based mapping to owner/page identity
+- eventually multi-gateway failover
+
+### Layer 5: Federation
+
+Allow multiple gateways or peer-run gateways to serve the same content.
+
+This is the practical path to "network-backed hosting".
+
+## Non-goal for early phases
+
+- Full browser-native libp2p page hosting
+- inventing a custom DNS system before the page bundle and gateway model work
+
+## Signed Audit and Verification Plan
+
+## Audit Model
+
+Every important action emits a signed event:
+
+- `monitor.created`
+- `monitor.updated`
+- `monitor.deleted`
+- `result.recorded`
+- `result.verified`
+- `status_page.published`
+- `status_page.replica_stored`
+- `peer.attestation`
+- `admin_key.rotated`
+
+## Verification Model
+
+Verification is a separate signed record:
+
+- original result is signed by source peer
+- verifier peers issue signed attestations
+- attestations reference the original event hash
+
+This makes trust composable and inspectable.
+
+## Storage Model
+
+Recommended tables:
+
+- `audit_events`
+- `audit_attestations`
+- `audit_replication`
+- `status_page_revisions`
+- `status_page_bundles`
+- `status_page_replicas`
+
+## API Model
+
+Add query APIs for:
+
+- audit event timeline
+- event detail
+- verification status
+- peer attestation list
+- replication state
+
+## Phased Roadmap
+
+## Phase 0: Stabilize Foundations
+
+Target: 2-3 weeks
+
+Deliverables:
+
+- choose and document final architecture boundaries
+- remove obsolete schema paths
+- identify canonical model ownership
+- replace placeholder/starter docs with accurate docs
+
+Tasks:
+
+1. Mark Rust migrations as the only DB source.
+2. Archive/remove old Go migration SQL.
+3. Remove duplicate or obsolete Go models.
+4. Publish an architecture decision record for:
+   - runtime ownership
+   - schema ownership
+   - API ownership
+   - event ownership
+
+Exit criteria:
+
+- no ambiguity about which layer owns what
+- no competing schema truth in active code paths
+
+## Phase 1: Contract Discipline
+
+Target: 2-3 weeks
+
+Deliverables:
+
+- generated type flow across Rust, Go, and TS
+- compatibility checks in CI
+- cleaned-up API contract surface
+
+Tasks:
+
+1. Audit all proto services and classify:
+   - implemented
+   - planned
+   - remove/defer
+2. Implement or hide missing services in nav/docs.
+3. Add schema compatibility tests.
+4. Add generated client usage rules for frontend.
+
+Exit criteria:
+
+- frontend never relies on undocumented handwritten API shapes
+- Go and Astro consume generated contracts consistently
+
+## Phase 2: Service Refactor
+
+Target: 3-5 weeks
+
+Deliverables:
+
+- clear domain/runtime module boundaries in Rust
+- reduced coupling between monitoring, P2P, and trust logic
+
+Tasks:
+
+1. Split orchestrator responsibilities into domain services.
+2. Move P2P-specific logic behind explicit interfaces.
+3. Move trust/signature verification into dedicated runtime modules.
+4. Define message boundaries for:
+   - monitor coordination
+   - result replication
+   - audit replication
+   - status-page bundle replication
+
+Exit criteria:
+
+- core workflows can be described without crossing too many modules
+- transport concerns are isolated from domain concerns
+
+## Phase 3: Trust Hardening
+
+Target: 2-4 weeks
+
+Deliverables:
+
+- real signature verification
+- canonical serialization rules
+- admin trust chain no longer uses placeholder checks
+
+Tasks:
+
+1. Replace placeholder verification in PeerUP.
+2. Replace placeholder admin trust-chain validation.
+3. Add deterministic payload canonicalization for signing.
+4. Add unit and property tests around signature validation.
+
+Exit criteria:
+
+- no trust-critical path returns success from placeholders
+
+## Phase 4: Status Page MVP
+
+Target: 4-6 weeks
+
+Deliverables:
+
+- status page CRUD
+- signed status page revisions
+- replicated bundle storage
+- gateway-served public pages
+
+Tasks:
+
+1. Implement `StatusPageService` in Go.
+2. Add persistence tables for pages and revisions.
+3. Define the signed page bundle format in Rust.
+4. Add replication protocol for page bundles.
+5. Build public page rendering against bundle data.
+
+Exit criteria:
+
+- a page remains accessible after the owner's node is offline
+
+## Phase 5: Settings and Network APIs
+
+Target: 2-3 weeks
+
+Deliverables:
+
+- `SettingsService`
+- `NetworkService`
+- live network map/settings pages
+
+Tasks:
+
+1. Implement settings storage/query APIs.
+2. Implement peer/network stats APIs from replicated/shared DB state.
+3. Replace placeholder frontend pages with live data.
+
+Exit criteria:
+
+- no major operator page is still mock-backed
+
+## Phase 6: Audit MVP
+
+Target: 4-6 weeks
+
+Deliverables:
+
+- signed event log
+- peer verification attestations
+- audit query APIs
+- audit explorer UI
+
+Tasks:
+
+1. Implement canonical event envelope.
+2. Persist signed events.
+3. Replicate events across peers.
+4. Add verification-attestation flows.
+5. Build query endpoints and UI inspection views.
+
+Exit criteria:
+
+- an operator can inspect what happened and who verified it
+
+## Immediate Backlog
+
+These are the first concrete work items to start now:
+
+1. Create `ARCHITECTURE.md` at repo root that defines ownership boundaries.
+2. Remove or clearly deprecate:
+- `apps/server/internal/db/migrations/001_initial_schema.sql`
+- obsolete/duplicate Go model paths
+3. Add a schema generation/verification script for `shared/database/schema.sql`.
+4. Define the canonical event envelope in protobuf or a shared schema document.
+5. Decide the status-page replication format:
+- bundle manifest
+- bundle assets
+- summary snapshot
+- signature format
+6. Implement `SettingsService` and `StatusPageService` before adding more frontend pages.
+7. Fix known correctness issues from the audit:
+- DB path panic risk
+- CORS policy
+- incorrect hardcoded frontend API port
+- ICMP exposure while unimplemented
+
+## Suggested Repository Restructure
+
+Proposed shape:
+
+- `apps/service/src/domain/`
+- `apps/service/src/runtime/`
+- `apps/service/src/storage/`
+- `apps/service/src/api_contract/` only if needed for shared internal mappings
+- `apps/server/internal/services/`
+- `apps/server/internal/readmodels/`
+- `apps/server/internal/repositories/`
+- `crates/peerup/src/transport/`
+- `crates/peerup/src/replication/`
+- `crates/peerup/src/verification/`
+
+This is not mandatory immediately, but the direction should be toward domain-aligned modules rather than mixed responsibility folders.
+
+## Delivery Strategy
+
+Run the project in three coordinated tracks:
+
+### Track A: Platform
+
+Owns:
+
+- schema discipline
+- service boundaries
+- Go API completion
+- frontend contract consistency
+
+### Track B: Distributed Runtime
+
+Owns:
+
+- PeerUP integration
+- result replication
+- status-page bundle replication
+- network stats plumbing
+
+### Track C: Trust and Audit
+
+Owns:
+
+- signing rules
+- event envelope
+- attestations
+- trust chain hardening
+- audit queries
+
+## Success Criteria
+
+The plan is working when:
+
+- one schema source exists
+- one API contract source exists
+- no critical security path uses placeholders
+- public status pages survive owner node downtime
+- every important event is signed and inspectable
+- frontend pages reflect actual backend capability
+
+## Recommended Order of Execution
+
+Do this in order:
+
+1. architecture freeze
+2. schema/API contract cleanup
+3. service/module boundary cleanup
+4. trust hardening
+5. status-page MVP with replicated bundles
+6. settings/network API completion
+7. signed audit system and verification UX
+
+## Bottom Line
+
+The right move is not "add more features now". The right move is:
+
+- fix ownership
+- fix contracts
+- fix trust boundaries
+- then build resilient public pages and auditing on top of that stable base
+
+If those foundations are done first, the later features you want are realistic. If not, public status pages, peer hosting, and signed audits will all be built on moving ground.

--- a/apps/client/src/lib/api/client.ts
+++ b/apps/client/src/lib/api/client.ts
@@ -1,0 +1,41 @@
+/**
+ * Uppe. API Client
+ * 
+ * ConnectRPC client for communicating with the Uppe. API server
+ * Supports Monitor and Result services
+ */
+
+import { createConnectTransport } from '@connectrpc/connect-web';
+import { createPromiseClient } from '@connectrpc/connect';
+import { MonitorService } from '../../gen/monitor/v1/monitor_connect';
+import { NetworkService } from '../../gen/network/v1/network_connect';
+import { ResultService } from '../../gen/result/v1/result_connect';
+import { SettingsService } from '../../gen/settings/v1/settings_connect';
+import { StatusPageService } from '../../gen/statuspage/v1/statuspage_connect';
+
+// API configuration
+const API_BASE_URL = import.meta.env.PUBLIC_API_URL || 'http://localhost:8080';
+
+// Create transport
+const transport = createConnectTransport({
+  baseUrl: API_BASE_URL,
+});
+
+// Create promise-based clients
+export const monitorClient = createPromiseClient(MonitorService, transport);
+export const networkClient = createPromiseClient(NetworkService, transport);
+export const resultClient = createPromiseClient(ResultService, transport);
+export const settingsClient = createPromiseClient(SettingsService, transport);
+export const statusPageClient = createPromiseClient(StatusPageService, transport);
+
+/**
+ * Health check - verify API is reachable
+ */
+export async function healthCheck(): Promise<boolean> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/health`);
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/apps/client/src/lib/api/index.ts
+++ b/apps/client/src/lib/api/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Uppe. API Module
+ * 
+ * Direct ConnectRPC client access for fully static bundle compatibility.
+ * All pages import and use these clients directly without wrapper functions,
+ * enabling the frontend to be deployed as a static site in the future.
+ * 
+ * Usage:
+ * ```astro
+ * ---
+ * import { monitorClient, resultClient } from '../lib/api';
+ * 
+ * const monitors = await monitorClient.listMonitors({ page: 1, pageSize: 100 });
+ * const results = await resultClient.getResults({ monitorId: 'mon_1', ... });
+ * ---
+ * ```
+ */
+
+export { monitorClient, networkClient, resultClient, settingsClient, statusPageClient } from './client';
+
+// Export all generated types for convenience
+export * from '../gen/monitor/v1/monitor_pb';
+export * from '../gen/network/v1/network_pb';
+export * from '../gen/result/v1/result_pb';
+export * from '../gen/common/v1/common_pb';
+export * from '../gen/settings/v1/settings_pb';
+export * from '../gen/statuspage/v1/statuspage_pb';
+
+/**
+ * Health check - verify API is reachable
+ */
+export async function healthCheck(): Promise<boolean> {
+  try {
+    const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8080';
+    const response = await fetch(new URL('/health', apiUrl).toString(), {
+      method: 'GET',
+    });
+    return response.ok;
+  } catch (error) {
+    console.warn('Health check failed:', error);
+    return false;
+  }
+}

--- a/apps/client/src/lib/services/statusPageService.ts
+++ b/apps/client/src/lib/services/statusPageService.ts
@@ -1,0 +1,281 @@
+/**
+ * Status Pages Service
+ * Manages public status pages linked to monitors through the Connect API.
+ */
+
+import { statusPageClient } from '../api/client';
+import {
+  CreateStatusPageRequest,
+  DeleteStatusPageRequest,
+  GetStatusPageRequest,
+  RecordVisitRequest,
+  UpdateStatusPageRequest,
+} from '../../gen/statuspage/v1/statuspage_pb';
+
+export interface StatusPage {
+  id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  monitorIds: string[];
+  customDomain?: string;
+  isPublished: boolean;
+  displayIncidents: boolean;
+  displayUptime: boolean;
+  refreshInterval: number;
+  createdAt: Date;
+  updatedAt: Date;
+  customCSS?: string;
+  companyName?: string;
+  companyLogo?: string;
+}
+
+export interface StatusPageSettings {
+  theme: 'light' | 'dark' | 'auto';
+  language: string;
+  timezone: string;
+  showResponseTime: boolean;
+  showCheckFrequency: boolean;
+}
+
+export interface PublicStatusPageData {
+  page: StatusPage;
+  settings: StatusPageSettings;
+  monitors: Array<{
+    id: string;
+    name: string;
+    status: 'up' | 'down' | 'degraded' | 'unknown';
+    lastUpdated: Date;
+    uptime24h: number;
+    uptime30d: number;
+    averageResponseTime: number;
+  }>;
+  incidents: Array<{
+    id: string;
+    title: string;
+    description: string;
+    startTime: Date;
+    endTime?: Date;
+    status: 'investigating' | 'identified' | 'monitoring' | 'resolved';
+    affectedServices: string[];
+  }>;
+}
+
+function toLocalStatusPage(page: {
+  id: string;
+  title: string;
+  slug: string;
+  description: string;
+  monitorIds: string[];
+  customDomain: string;
+  isActive: boolean;
+  createdAt: bigint | number | string;
+  updatedAt: bigint | number | string;
+  logoUrl: string;
+}): StatusPage {
+  return {
+    id: page.id,
+    name: page.title,
+    slug: page.slug,
+    description: page.description,
+    monitorIds: page.monitorIds,
+    customDomain: page.customDomain || undefined,
+    isPublished: page.isActive,
+    displayIncidents: true,
+    displayUptime: true,
+    refreshInterval: 30,
+    createdAt: new Date(Number(page.createdAt) * 1000),
+    updatedAt: new Date(Number(page.updatedAt) * 1000),
+    companyLogo: page.logoUrl || undefined,
+  };
+}
+
+export async function createStatusPage(data: {
+  name: string;
+  slug: string;
+  description?: string;
+  monitorIds: string[];
+  companyName?: string;
+  customDomain?: string;
+}): Promise<{ success: boolean; page?: StatusPage; error?: string }> {
+  try {
+    const created = await statusPageClient.createStatusPage(new CreateStatusPageRequest({
+      title: data.name,
+      slug: data.slug,
+      description: data.description ?? '',
+      monitorIds: data.monitorIds,
+    }));
+
+    return {
+      success: true,
+      page: {
+        ...toLocalStatusPage(created),
+        companyName: data.companyName,
+        customDomain: created.customDomain || data.customDomain,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to create status page',
+    };
+  }
+}
+
+export async function getStatusPage(slug: string): Promise<{
+  success: boolean;
+  page?: PublicStatusPageData;
+  error?: string;
+}> {
+  try {
+    const page = await statusPageClient.getStatusPage(new GetStatusPageRequest({
+      identifier: { case: 'slug', value: slug },
+    }));
+
+    return {
+      success: true,
+      page: {
+        page: toLocalStatusPage(page),
+        settings: {
+          theme: 'light',
+          language: 'en',
+          timezone: 'UTC',
+          showResponseTime: true,
+          showCheckFrequency: true,
+        },
+        monitors: page.monitorIds.map((monitorId) => ({
+          id: monitorId,
+          name: monitorId,
+          status: page.uptime >= 99 ? 'up' as const : page.uptime >= 95 ? 'degraded' as const : 'down' as const,
+          lastUpdated: new Date(Number(page.updatedAt) * 1000),
+          uptime24h: page.uptime,
+          uptime30d: page.uptime,
+          averageResponseTime: 0,
+        })),
+        incidents: [],
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to fetch status page',
+    };
+  }
+}
+
+export async function updateStatusPage(
+  id: string,
+  data: Partial<StatusPage>
+): Promise<{ success: boolean; page?: StatusPage; error?: string }> {
+  try {
+    const updated = await statusPageClient.updateStatusPage(new UpdateStatusPageRequest({
+      id,
+      title: data.name,
+      slug: data.slug,
+      description: data.description,
+      monitorIds: data.monitorIds ?? [],
+      isActive: data.isPublished,
+      logoUrl: data.companyLogo,
+    }));
+
+    return {
+      success: true,
+      page: {
+        ...toLocalStatusPage(updated),
+        companyName: data.companyName,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to update status page',
+    };
+  }
+}
+
+export async function publishStatusPage(id: string): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    await statusPageClient.updateStatusPage(new UpdateStatusPageRequest({
+      id,
+      isActive: true,
+    }));
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to publish status page',
+    };
+  }
+}
+
+export async function deleteStatusPage(id: string): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    await statusPageClient.deleteStatusPage(new DeleteStatusPageRequest({ id }));
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to delete status page',
+    };
+  }
+}
+
+export async function getMonitorUptime(
+  _monitorId: string,
+  _days: number = 30
+): Promise<{
+  success: boolean;
+  uptime?: number;
+  incidents?: number;
+  avgResponseTime?: number;
+  error?: string;
+}> {
+  return {
+    success: true,
+    uptime: 100,
+    incidents: 0,
+    avgResponseTime: 0,
+  };
+}
+
+export async function validateSlug(slug: string): Promise<{
+  valid: boolean;
+  message?: string;
+}> {
+  const slugRegex = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+  if (!slugRegex.test(slug)) {
+    return {
+      valid: false,
+      message: 'Slug must contain only lowercase letters, numbers, and hyphens',
+    };
+  }
+
+  if (slug.length < 3) {
+    return {
+      valid: false,
+      message: 'Slug must be at least 3 characters long',
+    };
+  }
+
+  try {
+    await statusPageClient.getStatusPage(new GetStatusPageRequest({
+      identifier: { case: 'slug', value: slug },
+    }));
+    return {
+      valid: false,
+      message: 'Slug is already in use',
+    };
+  } catch {
+    return { valid: true };
+  }
+}
+
+export async function recordStatusPageVisit(id: string): Promise<void> {
+  await statusPageClient.recordVisit(new RecordVisitRequest({ statusPageId: id }));
+}

--- a/apps/client/src/pages/network-map.astro
+++ b/apps/client/src/pages/network-map.astro
@@ -1,6 +1,7 @@
 ---
 import Header from "$components/Header.astro";
 import Layout from "$layouts/Layout.astro";
+import { networkClient } from "../lib/api/client";
 import { 
   Section, 
   Grid, 
@@ -12,8 +13,55 @@ import {
   MapLegend,
   WorldMap,
   PeerListItem,
-  HealthMetric
+  HealthMetric,
+  Alert,
+  Icon,
+  Flex,
+  Stack
 } from "$ui";
+import {
+  GetNetworkHealthRequest,
+  GetNetworkStatsRequest,
+  GetPeerDistributionRequest,
+  ListPeersRequest,
+  PeerStatus,
+} from "../gen/network/v1/network_pb";
+
+const [networkStats, peerResponse, networkHealth, peerDistribution] = await Promise.all([
+  networkClient.getNetworkStats(new GetNetworkStatsRequest({})),
+  networkClient.listPeers(new ListPeersRequest({ page: 1, pageSize: 8, sortBy: 'contribution' })),
+  networkClient.getNetworkHealth(new GetNetworkHealthRequest({})),
+  networkClient.getPeerDistribution(new GetPeerDistributionRequest({})),
+]);
+
+const myNodeId = networkStats.myNodeId || 'node-unannounced';
+const totalPeers = Number(networkStats.totalPeers);
+const onlinePeers = Number(networkStats.onlinePeers);
+const checksPerHour = Number(networkStats.checksPerHour);
+const checksPerformedToday = Number(networkStats.checksPerformedToday);
+const checksReceivedToday = Number(networkStats.checksReceivedToday);
+const bandwidthUsedMb = Number(networkStats.bandwidthUsedMb);
+const bandwidthLimitMb = Number(networkStats.bandwidthLimitMb);
+const shareRatio = networkStats.shareRatio;
+const coveragePercentage = networkStats.coveragePercentage;
+
+const formatLocation = (peer: { location?: { city?: string; region?: string; country?: string } }) => {
+  const parts = [peer.location?.city, peer.location?.region, peer.location?.country].filter(Boolean);
+  return parts.length > 0 ? parts.join(', ') : 'Unknown region';
+};
+
+const toUiStatus = (status: PeerStatus): 'online' | 'warning' | 'offline' | 'error' => {
+  switch (status) {
+    case PeerStatus.ONLINE:
+      return 'online';
+    case PeerStatus.SLOW:
+      return 'warning';
+    case PeerStatus.OFFLINE:
+      return 'offline';
+    default:
+      return 'error';
+  }
+};
 
 const legendItems = [
   { status: 'online' as const, label: 'Online' },
@@ -21,20 +69,24 @@ const legendItems = [
   { status: 'error' as const, label: 'Offline' }
 ];
 
-const topPeers = [
-  { peerId: 'peer_a1b2c3d4', location: 'Tokyo, Japan', checksPerDay: 12450, status: 'online' as const },
-  { peerId: 'peer_e5f6g7h8', location: 'New York, USA', checksPerDay: 11230, status: 'online' as const },
-  { peerId: 'peer_i9j0k1l2', location: 'London, UK', checksPerDay: 10890, status: 'online' as const },
-  { peerId: 'peer_m3n4o5p6', location: 'Sydney, Australia', checksPerDay: 9450, status: 'online' as const },
-  { peerId: 'peer_q7r8s9t0', location: 'São Paulo, Brazil', checksPerDay: 8760, status: 'warning' as const }
-];
+const topPeers = peerResponse.peers.map((peer) => ({
+  peerId: peer.peerId,
+  location: formatLocation(peer),
+  checksPerDay: Number(peer.checksPerDay),
+  status: toUiStatus(peer.status),
+}));
 
 const healthMetrics = [
-  { label: 'Consensus Rate', value: 96, unit: '%', variant: 'success' as const },
-  { label: 'Avg Latency', value: 78, unit: 'ms', variant: 'warning' as const },
-  { label: 'Redundancy', value: 8.5, unit: 'x', variant: 'primary' as const },
-  { label: 'Churn Rate', value: 1.2, unit: '%', variant: 'success' as const }
+  { label: 'Consensus', value: Math.round(networkHealth.consensusRate), unit: '%', variant: 'success' as const },
+  { label: 'Redundancy', value: Math.round(networkHealth.redundancyFactor * 10) / 10, unit: 'x', variant: 'primary' as const },
+  { label: 'Churn (24h)', value: Math.round(networkHealth.churnRate * 10) / 10, unit: '%', variant: 'warning' as const },
+  { label: 'Bandwidth', value: bandwidthLimitMb > 0 ? Math.round((bandwidthUsedMb / bandwidthLimitMb) * 100) : 0, unit: '%', variant: 'primary' as const }
 ];
+
+const regionSummary = peerDistribution.regions.slice(0, 4).map((region) => ({
+  label: region.region,
+  value: `${region.onlineCount}/${region.peerCount} online`,
+}));
 ---
 
 <Layout title="Network Map - Uppe." description="Visualize the P2P monitoring network">
@@ -46,29 +98,44 @@ const healthMetrics = [
       <Paragraph class="text-secondary">Real-time visualization of the Uppe. monitoring network</Paragraph>
     </Section>
 
+    <!-- Live Network Banner -->
+    <Section>
+      <Alert variant="info">
+        <strong>Live network data.</strong> This page now reads from the shared network tables exposed by
+        the Go API. Some advanced metrics are still coarse until peer verification and audit pipelines land.
+      </Alert>
+    </Section>
+
     <!-- Network Stats -->
     <Section>
       <Grid cols="4">
         <MetricCard 
           title="Total Peers" 
-          value="1,823"
+          value={String(totalPeers)}
           icon="NETWORK"
+          change={`${onlinePeers} online`}
+          changeType={onlinePeers > 0 ? "positive" : "neutral"}
         />
         <MetricCard 
-          title="Online Peers" 
-          value="1,647"
+          title="Node ID" 
+          value={myNodeId.slice(0, 12)}
           icon="ANALYTICS"
-          changeType="positive"
+          change={totalPeers > 1 ? "Connected to live peer set" : "Single-node or sparse network"}
+          changeType="neutral"
         />
         <MetricCard 
           title="Checks/Hour" 
-          value="2.4M"
+          value={String(checksPerHour)}
           icon="PERFORMANCE"
+          change={`${checksPerformedToday} local / ${checksReceivedToday} remote today`}
+          changeType={checksPerHour > 0 ? "positive" : "neutral"}
         />
         <MetricCard 
           title="Coverage" 
-          value="98.7%"
+          value={`${Math.round(coveragePercentage)}%`}
           icon="GLOBAL"
+          change={`${peerDistribution.regions.length} regions discovered`}
+          changeType={coveragePercentage >= 50 ? "positive" : "warning"}
         />
       </Grid>
     </Section>
@@ -81,8 +148,12 @@ const healthMetrics = [
             <Heading level={2}>Global Network</Heading>
             <MapLegend items={legendItems} />
           </div>
-
+          
           <WorldMap />
+          
+          <Paragraph class="text-secondary text-center mt-4">
+            Geographic rendering is still generic, but the peer and region counts below now come from the live P2P tables.
+          </Paragraph>
         </CardBody>
       </Card>
     </Section>
@@ -90,19 +161,21 @@ const healthMetrics = [
     <!-- Peer Details -->
     <Section>
       <Grid cols="2">
-        <!-- Top Contributors -->
+        <!-- This Node -->
         <Card>
           <CardBody>
-            <Heading level={3} class="mb-4">Top Contributors</Heading>
+            <Heading level={3} class="mb-4">Your Node</Heading>
             <div class="space-y-4">
-              {topPeers.map(peer => (
-                <PeerListItem 
-                  peerId={peer.peerId}
-                  location={peer.location}
-                  checksPerDay={peer.checksPerDay}
-                  status={peer.status}
-                />
-              ))}
+              <PeerListItem 
+                peerId={myNodeId}
+                location={regionSummary[0]?.label || 'Local installation'}
+                checksPerDay={checksPerformedToday}
+                status="online"
+              />
+              <Paragraph class="text-secondary text-sm">
+                Your node is identified from the shared results database. The live contribution ratio is
+                {` ${shareRatio.toFixed(2)} `}and current network score is {networkStats.contributionScore.toFixed(2)}.
+              </Paragraph>
             </div>
           </CardBody>
         </Card>
@@ -121,9 +194,60 @@ const healthMetrics = [
                 />
               ))}
             </div>
+            <Paragraph class="text-secondary text-sm mt-4">
+              Average observed latency: {Math.round(networkHealth.avgLatencyMs)}ms
+            </Paragraph>
           </CardBody>
         </Card>
       </Grid>
+    </Section>
+
+    <!-- Peer and Region Overview -->
+    <Section>
+      <Card>
+        <CardBody>
+          <Heading level={3} class="mb-4">Top Peers</Heading>
+          <Stack gap="3" class="mb-6">
+            {topPeers.length > 0 ? topPeers.map((peer) => (
+              <PeerListItem 
+                peerId={peer.peerId}
+                location={peer.location}
+                checksPerDay={peer.checksPerDay}
+                status={peer.status}
+              />
+            )) : (
+              <Paragraph class="text-secondary text-sm">
+                No replicated peers have been recorded yet.
+              </Paragraph>
+            )}
+          </Stack>
+
+          <Heading level={3} class="mb-4">Region Summary</Heading>
+          <Grid cols="3" gap="4">
+            {regionSummary.length > 0 ? regionSummary.map((region) => (
+              <div class="p-4 bg-bg-tertiary rounded-lg">
+                <Flex align="center" gap="2" class="mb-2">
+                  <Icon icon="GLOBAL" class="size-5 text-accent-primary" />
+                  <Heading level={4}>{region.label}</Heading>
+                </Flex>
+                <Paragraph class="text-secondary text-sm">
+                  {region.value}
+                </Paragraph>
+              </div>
+            )) : (
+              <div class="p-4 bg-bg-tertiary rounded-lg">
+                <Flex align="center" gap="2" class="mb-2">
+                  <Icon icon="GLOBAL" class="size-5 text-accent-primary" />
+                  <Heading level={4}>No regions yet</Heading>
+                </Flex>
+                <Paragraph class="text-secondary text-sm">
+                  Peer geography will appear here once nodes publish replicated location metadata.
+                </Paragraph>
+              </div>
+            )}
+          </Grid>
+        </CardBody>
+      </Card>
     </Section>
   </main>
 </Layout>

--- a/apps/client/src/pages/settings.astro
+++ b/apps/client/src/pages/settings.astro
@@ -3,7 +3,6 @@ import Header from "$components/Header.astro";
 import Layout from "$layouts/Layout.astro";
 import { 
   Section, 
-  Grid, 
   Card, 
   CardBody, 
   Heading, 
@@ -16,8 +15,48 @@ import {
   Icon,
   Label,
   Alert,
-  Badge
+  Badge,
+  Stack,
+  Flex
 } from "$ui";
+import { settingsClient } from "../lib/api/client";
+import { GetNodeIdentityRequest, GetSettingsRequest, PeerDiscoveryMethod } from "../gen/settings/v1/settings_pb";
+
+const apiBaseUrl = import.meta.env.PUBLIC_API_URL || "http://localhost:8080";
+let settings;
+let nodeIdentity;
+let settingsError: string | null = null;
+
+try {
+  settings = await settingsClient.getSettings(new GetSettingsRequest());
+  nodeIdentity = await settingsClient.getNodeIdentity(new GetNodeIdentityRequest());
+} catch (error) {
+  console.error("[Settings] Failed to fetch settings:", error);
+  settingsError = "Failed to load settings from the API server.";
+}
+
+const account = settings?.account;
+const notifications = settings?.notifications;
+const network = settings?.network;
+const monitoring = settings?.monitoring;
+const cluster = settings?.cluster;
+
+// Get database info for display
+const dbPath = import.meta.env.DATABASE_LIBSQL_PATH || 'shared/data/libsql.db';
+const apiUrlDisplay = apiBaseUrl;
+const joinedAt = nodeIdentity?.joinedNetworkAt ? new Date(Number(nodeIdentity.joinedNetworkAt) * 1000) : null;
+const peerDiscoveryLabel = (() => {
+  switch (network?.discoveryMethod) {
+    case PeerDiscoveryMethod.PEER_DISCOVERY_DHT_ONLY:
+      return "DHT Only";
+    case PeerDiscoveryMethod.PEER_DISCOVERY_BOOTSTRAP_ONLY:
+      return "Bootstrap Only";
+    case PeerDiscoveryMethod.PEER_DISCOVERY_MANUAL:
+      return "Manual Peers";
+    default:
+      return "DHT + Bootstrap";
+  }
+})();
 ---
 
 <Layout title="Settings" description="Configure your Uppe. monitoring settings">
@@ -26,10 +65,54 @@ import {
   <main class="min-h-screen">
     <Section>
       <Heading level={1} class="mb-2">Settings</Heading>
-      <Paragraph class="text-secondary">Configure your monitoring preferences and account settings</Paragraph>
+      <Paragraph class="text-secondary">Configure your monitoring preferences</Paragraph>
     </Section>
 
     <div class="space-y-8">
+      <!-- Node Information -->
+      <Section>
+        <Card>
+          <CardBody>
+            <Heading level={2} class="mb-4">Node Information</Heading>
+            <div class="space-y-4">
+              {settingsError && (
+                <Alert variant="error">
+                  <strong>Settings unavailable.</strong> {settingsError}
+                </Alert>
+              )}
+              {!settingsError && (
+                <Alert variant="info">
+                  <strong>Live API data.</strong> This page now reads settings and node identity from the Go API. Save actions are still pending.
+                </Alert>
+              )}
+              
+              <div class="grid grid-cols-2 gap-4 mt-4">
+                <div class="p-4 bg-bg-tertiary rounded-lg">
+                  <Paragraph color="secondary" class="text-sm mb-1">Node Type</Paragraph>
+                  <Paragraph class="font-medium">Standalone</Paragraph>
+                </div>
+                <div class="p-4 bg-bg-tertiary rounded-lg">
+                  <Paragraph color="secondary" class="text-sm mb-1">Database</Paragraph>
+                  <Paragraph class="font-medium text-sm font-mono">{dbPath}</Paragraph>
+                </div>
+                <div class="p-4 bg-bg-tertiary rounded-lg">
+                  <Paragraph color="secondary" class="text-sm mb-1">API Server</Paragraph>
+                  <Paragraph class="font-medium">{apiUrlDisplay}</Paragraph>
+                </div>
+                <div class="p-4 bg-bg-tertiary rounded-lg">
+                  <Paragraph color="secondary" class="text-sm mb-1">Node ID</Paragraph>
+                  <Paragraph class="font-medium text-sm font-mono">{nodeIdentity?.nodeId || "unknown"}</Paragraph>
+                </div>
+                <div class="p-4 bg-bg-tertiary rounded-lg">
+                  <Paragraph color="secondary" class="text-sm mb-1">Joined Network</Paragraph>
+                  <Paragraph class="font-medium">{joinedAt ? joinedAt.toLocaleDateString() : "unknown"}</Paragraph>
+                </div>
+              </div>
+            </div>
+          </CardBody>
+        </Card>
+      </Section>
+
       <!-- Account Settings -->
       <Section>
         <Card>
@@ -41,15 +124,53 @@ import {
                 <Input 
                   id="displayName"
                   type="text"
-                  value="Uppe. User"
+                  value={account?.displayName || ""}
+                  placeholder="Your node name"
                 />
               </FormGroup>
               <FormGroup>
-                <Label for="email">Email Address</Label>
+                <Label for="email">Email Address (for notifications)</Label>
                 <Input 
                   id="email"
                   type="email"
-                  value="user@example.com"
+                  value={account?.email || ""}
+                  placeholder="user@example.com"
+                />
+                <Paragraph color="secondary" class="text-xs mt-1">
+                  Optional - used for alert notifications when configured
+                </Paragraph>
+              </FormGroup>
+            </div>
+          </CardBody>
+        </Card>
+      </Section>
+
+      <!-- Monitoring Defaults -->
+      <Section>
+        <Card>
+          <CardBody>
+            <Heading level={2} class="mb-4">Monitoring Defaults</Heading>
+            <Paragraph color="secondary" class="mb-4 text-sm">
+              Default settings for new monitors. Individual monitors can override these.
+            </Paragraph>
+            <div class="space-y-4">
+              <FormGroup>
+                <Label for="checkInterval">Default Check Interval</Label>
+                <Select id="checkInterval" value={(monitoring?.defaultIntervalSeconds || 60).toString()}>
+                  <option value="30">30 seconds</option>
+                  <option value="60">1 minute</option>
+                  <option value="300">5 minutes</option>
+                  <option value="600">10 minutes</option>
+                </Select>
+              </FormGroup>
+              <FormGroup>
+                <Label for="timeout">Default Timeout (seconds)</Label>
+                <Input 
+                  id="timeout"
+                  type="number"
+                  value={monitoring?.defaultTimeoutSeconds || 10}
+                  min="5"
+                  max="120"
                 />
               </FormGroup>
             </div>
@@ -61,28 +182,31 @@ import {
       <Section>
         <Card>
           <CardBody>
-            <Heading level={2} class="mb-4">Notification Settings</Heading>
-            <div class="space-y-4">
+            <Flex align="center" justify="between" class="mb-4">
+              <Heading level={2}>Notification Settings</Heading>
+              <Badge variant="secondary">Coming Soon</Badge>
+            </Flex>
+            <div class="space-y-4 opacity-60 pointer-events-none">
               <Toggle 
                 label="Email Notifications"
                 description="Receive alerts when monitors go down"
-                checked={true}
+                checked={notifications?.emailNotifications || false}
                 id="emailNotifications"
                 name="emailNotifications"
               />
               <Toggle 
-                label="Incident Reports"
-                description="Weekly summary of incidents and uptime"
-                checked={false}
+                label="Weekly Reports"
+                description="Weekly summary of uptime and incidents"
+                checked={notifications?.incidentReports || false}
                 id="incidentReports"
                 name="incidentReports"
               />
               <Toggle 
-                label="P2P Network Updates"
-                description="Updates about network status and improvements"
-                checked={true}
-                id="networkUpdates"
-                name="networkUpdates"
+                label="Webhook Notifications"
+                description="Send alerts to external services via webhooks"
+                checked={false}
+                id="webhookNotifications"
+                name="webhookNotifications"
               />
             </div>
           </CardBody>
@@ -93,21 +217,25 @@ import {
       <Section>
         <Card>
           <CardBody>
-            <Heading level={2} class="mb-4">P2P Network Settings</Heading>
-            <div class="space-y-4">
+            <Flex align="center" justify="between" class="mb-4">
+              <Heading level={2}>P2P Network Settings</Heading>
+              <Badge variant="secondary">Coming Soon</Badge>
+            </Flex>
+            <Alert variant="info" class="mb-4">
+              P2P monitoring is under active development. When enabled, your node will join a decentralized 
+              network of monitoring peers for distributed, trust-verified monitoring.
+            </Alert>
+            <div class="space-y-4 opacity-60 pointer-events-none">
               <FormGroup>
                 <Label for="peerDiscovery">Peer Discovery Method</Label>
                 <Select id="peerDiscovery">
-                  <option>DHT + Bootstrap Nodes</option>
-                  <option>DHT Only</option>
-                  <option>Bootstrap Nodes Only</option>
-                  <option>Manual Peer List</option>
+                  <option selected>{peerDiscoveryLabel}</option>
                 </Select>
               </FormGroup>
               <Toggle 
                 label="Contribute to Network"
-                description="Help monitor other services in the network"
-                checked={true}
+                description="Help monitor services for other peers in the network"
+                checked={network?.contributeToNetwork || false}
                 id="contributeToNetwork"
                 name="contributeToNetwork"
               />
@@ -116,61 +244,9 @@ import {
                 <Input 
                   id="maxBandwidth"
                   type="number"
-                  value="100"
+                  value={network?.maxBandwidthMbPerDay ? Number(network.maxBandwidthMbPerDay) : 100}
                 />
               </FormGroup>
-              <FormGroup>
-                <Label for="maxChecks">Max Concurrent Checks</Label>
-                <Input 
-                  id="maxChecks"
-                  type="number"
-                  value="50"
-                  min="1"
-                  max="200"
-                />
-              </FormGroup>
-              <Toggle 
-                label="Auto-Accept Monitoring Requests"
-                description="Automatically accept requests to monitor services"
-                checked={true}
-                id="autoAcceptRequests"
-                name="autoAcceptRequests"
-              />
-            </div>
-          </CardBody>
-        </Card>
-      </Section>
-
-      <!-- Advanced Settings -->
-      <Section>
-        <Card>
-          <CardBody>
-            <Heading class="mb-4">Advanced Settings</Heading>
-            <div class="space-y-4">
-              <FormGroup>
-                <Label for="checkInterval">Check Interval</Label>
-                <Select id="checkInterval">
-                  <option>30 seconds</option>
-                  <option>1 minute</option>
-                  <option>5 minutes</option>
-                  <option>10 minutes</option>
-                </Select>
-              </FormGroup>
-              <FormGroup>
-                <Label for="timeout">Timeout (seconds)</Label>
-                <Input 
-                  id="timeout"
-                  type="number"
-                  value="30"
-                />
-              </FormGroup>
-              <Toggle 
-                label="Detailed Logging"
-                description="Store detailed logs of all monitoring activities"
-                checked={false}
-                id="detailedLogging"
-                name="detailedLogging"
-              />
             </div>
           </CardBody>
         </Card>
@@ -180,71 +256,79 @@ import {
       <Section>
         <Card>
           <CardBody>
-            <Heading level={2} class="mb-4">Cluster Management</Heading>
+            <Flex align="center" justify="between" class="mb-4">
+              <Heading level={2}>Cluster Management</Heading>
+              <Badge variant="secondary">Coming Soon</Badge>
+            </Flex>
+            <Alert variant="info" class="mb-4">
+              Clusters allow groups of nodes to collaborate on monitoring. Create public or private 
+              clusters for team monitoring or join existing clusters.
+            </Alert>
             
-            <div class="space-y-6">
-              <Card class="border-2 border-primary">
-                <CardBody>
-                  <div class="flex items-center justify-between">
-                    <div class="flex-1">
-                      <div class="flex items-center gap-2 mb-2">
-                        <Heading level={3}>Cluster Visibility</Heading>
-                        <Badge variant="primary">Public</Badge>
-                      </div>
-                      <Paragraph class="text-secondary text-sm">
-                        Your monitoring cluster is currently public. Other users can discover and join your cluster for collaborative monitoring.
-                      </Paragraph>
-                    </div>
-                    <div class="ml-4">
-                      <Toggle 
-                        label=""
-                        checked={true}
-                        id="clusterVisibility"
-                        name="clusterVisibility"
-                      />
-                    </div>
-                  </div>
-                </CardBody>
-              </Card>
+            <div class="space-y-4 opacity-60 pointer-events-none">
+              <Toggle 
+                label="Enable Cluster Mode"
+                description="Create or join a monitoring cluster"
+                checked={!!cluster}
+                id="clusterEnabled"
+                name="clusterEnabled"
+              />
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <FormGroup>
+                  <Label for="clusterName">Cluster Name</Label>
+                  <Input 
+                    id="clusterName"
+                    type="text"
+                    value={cluster?.clusterName || ""}
+                    placeholder="My Monitoring Cluster"
+                  />
+                </FormGroup>
+                <FormGroup>
+                  <Label for="clusterVisibility">Visibility</Label>
+                  <Select id="clusterVisibility">
+                    <option value={cluster?.isPublic ? "public" : "private"}>
+                      {cluster?.isPublic ? "Public" : "Private"}
+                    </option>
+                  </Select>
+                </FormGroup>
+              </div>
+            </div>
+          </CardBody>
+        </Card>
+      </Section>
 
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div class="space-y-4">
-                  <FormGroup>
-                    <Label for="clusterName">Cluster Name</Label>
-                    <Input 
-                      id="clusterName"
-                      type="text"
-                      value="My Monitoring Cluster"
-                    />
-                  </FormGroup>
-                  <FormGroup>
-                    <Label for="maxClusterSize">Max Cluster Size</Label>
-                    <Select id="maxClusterSize">
-                      <option value="10">10 peers</option>
-                      <option value="25" selected>25 peers</option>
-                      <option value="50">50 peers</option>
-                      <option value="100">100 peers</option>
-                    </Select>
-                  </FormGroup>
-                </div>
-                <div class="space-y-4">
-                  <FormGroup>
-                    <Label for="joinPolicy">Join Policy</Label>
-                    <Select id="joinPolicy">
-                      <option value="open" selected>Open (Anyone can join)</option>
-                      <option value="approval">Approval Required</option>
-                      <option value="invite">Invite Only</option>
-                    </Select>
-                  </FormGroup>
-                  <FormGroup>
-                    <Label for="minMRScore">Minimum MR Score</Label>
-                    <Select id="minMRScore">
-                      <option value="0">No minimum</option>
-                      <option value="1">1.0 (Balanced)</option>
-                      <option value="1.5" selected>1.5 (Good contributor)</option>
-                      <option value="2">2.0 (Excellent contributor)</option>
-                    </Select>
-                  </FormGroup>
+      <!-- Data Management -->
+      <Section>
+        <Card>
+          <CardBody>
+            <Heading level={2} class="mb-4">Data Management</Heading>
+            <div class="space-y-4">
+              <FormGroup>
+                <Label for="dataRetention">Data Retention Period</Label>
+                <Select id="dataRetention" value={(monitoring?.resultRetentionDays || 30).toString()}>
+                  <option value="7">7 days</option>
+                  <option value="30">30 days</option>
+                  <option value="90">90 days</option>
+                  <option value="365">1 year</option>
+                  <option value="0">Forever</option>
+                </Select>
+                <Paragraph color="secondary" class="text-xs mt-1">
+                  How long to keep monitor results and historical data
+                </Paragraph>
+              </FormGroup>
+              
+              <div class="pt-4 border-t border-border-primary">
+                <Heading level={4} class="mb-2">Danger Zone</Heading>
+                <div class="flex items-center justify-between p-4 border border-red-500/30 rounded-lg bg-red-500/5">
+                  <div>
+                    <Paragraph class="font-medium">Clear All Data</Paragraph>
+                    <Paragraph color="secondary" class="text-sm">
+                      Delete all monitors, results, and settings. This cannot be undone.
+                    </Paragraph>
+                  </div>
+                  <Button variant="danger" size="sm">
+                    Clear Data
+                  </Button>
                 </div>
               </div>
             </div>
@@ -254,10 +338,13 @@ import {
 
       <!-- Save Button -->
       <Section>
-        <div class="flex justify-end">
-          <Button variant="primary" class="flex items-center gap-2">
+        <div class="flex justify-end gap-4">
+          <Button variant="secondary" disabled>
+            Reset to Defaults
+          </Button>
+          <Button variant="primary" class="flex items-center gap-2" disabled>
             <Icon icon="CONFIRM" />
-            Save Settings
+            Save Settings Soon
           </Button>
         </div>
       </Section>

--- a/apps/client/src/pages/status-pages.astro
+++ b/apps/client/src/pages/status-pages.astro
@@ -15,48 +15,38 @@ import {
   IconContainer,
   Flex,
   Stack,
-  Container
+  Container,
+  Alert
 } from "$ui";
 
-// Mock data for public status pages
-const statusPages = [
-	{
-		id: '1',
-		title: 'Production API Status',
-		slug: 'production-api',
-		url: 'https://api.example.com',
-		services: ['API Server', 'Database', 'CDN'],
-		uptime: 99.97,
-		visits: 1247,
-		lastIncident: '2024-01-10T08:15:00Z',
-		isActive: true,
-		created: '2024-01-01T00:00:00Z'
-	},
-	{
-		id: '2',
-		title: 'Website Status',
-		slug: 'website-status',
-		url: 'https://example.com',
-		services: ['Web Server', 'Load Balancer'],
-		uptime: 99.85,
-		visits: 856,
-		lastIncident: '2024-01-12T14:23:00Z',
-		isActive: true,
-		created: '2024-01-05T00:00:00Z'
-	},
-	{
-		id: '3',
-		title: 'Internal Tools',
-		slug: 'internal-tools',
-		url: 'https://tools.example.com',
-		services: ['Admin Panel', 'Monitoring Dashboard'],
-		uptime: 98.92,
-		visits: 234,
-		lastIncident: '2024-01-14T16:45:00Z',
-		isActive: false,
-		created: '2024-01-10T00:00:00Z'
-	}
-];
+// Import API client
+import { monitorClient, statusPageClient } from "../lib/api/client";
+import { ListStatusPagesRequest } from "../gen/statuspage/v1/statuspage_pb";
+
+// Fetch monitors to show what can be added to status pages
+let monitors: any[] = [];
+try {
+  const response = await monitorClient.listMonitors({ page: 1, pageSize: 100, filter: '' });
+  monitors = response.monitors || [];
+} catch (error) {
+  console.error('Failed to fetch monitors:', error);
+}
+
+let statusPages: any[] = [];
+try {
+  const response = await statusPageClient.listStatusPages(new ListStatusPagesRequest({ page: 1, pageSize: 50 }));
+  statusPages = response.statusPages || [];
+} catch (error) {
+  console.error('Failed to fetch status pages:', error);
+}
+
+// Calculate stats
+const totalPages = statusPages.length;
+const activePages = statusPages.filter((p: any) => p.isActive).length;
+const totalVisits = statusPages.reduce((sum: number, p: any) => sum + Number(p.visits || 0), 0);
+const avgUptime = statusPages.length > 0 
+  ? (statusPages.reduce((sum: number, p: any) => sum + Number(p.uptime || 0), 0) / statusPages.length).toFixed(1)
+  : '100.0';
 ---
 
 <Layout title="Public Status Pages - Uppe.">
@@ -70,11 +60,20 @@ const statusPages = [
 						<Heading level={1}>Public Status Pages</Heading>
 						<Paragraph color="secondary">Create and manage public status pages for your services</Paragraph>
 					</Stack>
-					<Button variant="primary">
-						Create New Page
+					<Button variant="primary" disabled={true}>
+						Create New Page Soon
 					</Button>
 				</Flex>
 			</Section>
+
+			{monitors.length === 0 && (
+				<Section>
+					<Alert variant="warning">
+						<strong>No monitors configured.</strong> Create some monitors first before setting up status pages.
+					<a href="/add-monitor" class="ml-2 text-accent-primary hover:underline">Create a monitor →</a>
+					</Alert>
+				</Section>
+			)}
 			
 			<!-- Quick Stats -->
 			<Section>
@@ -82,7 +81,7 @@ const statusPages = [
 					<Card>
 						<CardBody>
 							<MetricDisplay 
-								value={statusPages.length}
+								value={totalPages}
 								label="Total Pages"
 								color="primary"
 							/>
@@ -91,7 +90,7 @@ const statusPages = [
 					<Card>
 						<CardBody>
 							<MetricDisplay 
-								value={statusPages.filter(p => p.isActive).length}
+								value={activePages}
 								label="Active Pages"
 								color="success"
 							/>
@@ -100,7 +99,7 @@ const statusPages = [
 					<Card>
 						<CardBody>
 							<MetricDisplay 
-								value={statusPages.reduce((sum, p) => sum + p.visits, 0).toLocaleString()}
+								value={totalVisits.toLocaleString()}
 								label="Total Visits"
 								color="warning"
 							/>
@@ -109,7 +108,7 @@ const statusPages = [
 					<Card>
 						<CardBody>
 							<MetricDisplay 
-								value={`${(statusPages.reduce((sum, p) => sum + p.uptime, 0) / statusPages.length).toFixed(1)}%`}
+								value={`${avgUptime}%`}
 								label="Avg. Uptime"
 								color="primary"
 							/>
@@ -118,40 +117,116 @@ const statusPages = [
 				</Grid>
 			</Section>
 
-		<!-- Status Pages List -->
-		<Section>
-			<Grid cols="2" gap="4">
-				{statusPages.map((page) => (
-					<StatusPageCard
-						title={page.title}
-						slug={page.slug}
-						isActive={page.isActive}
-						services={page.services}
-						uptime={page.uptime}
-						visits={page.visits}
-						lastIncident={page.lastIncident}
-						created={page.created}
-					/>
-				))}
-			</Grid>
-		</Section>
+		{statusPages.length > 0 ? (
+			<!-- Status Pages List -->
+			<Section>
+				<Grid cols="2" gap="4">
+					{statusPages.map((page: any) => (
+						<StatusPageCard
+							title={page.title}
+							slug={page.slug}
+							isActive={page.isActive}
+							services={page.monitorIds.map((id: string) => monitors.find((m: any) => m.id === id)?.name || id)}
+							uptime={page.uptime}
+							visits={Number(page.visits)}
+							lastIncident={Number(page.lastIncident) > 0 ? new Date(Number(page.lastIncident) * 1000).toISOString() : new Date(Number(page.updatedAt) * 1000).toISOString()}
+							created={new Date(Number(page.createdAt) * 1000).toISOString()}
+						/>
+					))}
+				</Grid>
+			</Section>
+		) : (
+			<!-- Empty State / Create First Page CTA -->
+			<Section>
+				<Card>
+					<CardBody padding="xl">
+						<Stack align="center" gap="4">
+							<IconContainer variant="primary" size="lg">
+								<Icon icon="DASHBOARD" class="text-accent-primary" />
+							</IconContainer>
+							<Heading level={3}>Create Your First Status Page</Heading>
+							<Paragraph color="secondary" align="center" class="max-w-md">
+								Status pages let you share your service health with your users. 
+								They automatically update based on your monitor data.
+							</Paragraph>
+							
+							{monitors.length > 0 ? (
+								<Stack gap="2" align="center">
+									<Paragraph color="secondary" class="text-sm">
+										You have {monitors.length} monitor{monitors.length !== 1 ? 's' : ''} that can be added to a status page:
+									</Paragraph>
+									<div class="flex flex-wrap gap-2 justify-center">
+										{monitors.slice(0, 5).map((m: any) => (
+											<span class="px-2 py-1 bg-bg-tertiary rounded text-sm">{m.name}</span>
+										))}
+										{monitors.length > 5 && (
+											<span class="px-2 py-1 bg-bg-tertiary rounded text-sm">+{monitors.length - 5} more</span>
+										)}
+									</div>
+									<Button variant="primary" size="lg" class="mt-4" disabled={true}>
+										Create Status Page Soon
+									</Button>
+								</Stack>
+							) : (
+								<Stack gap="2" align="center">
+									<Paragraph color="secondary" class="text-sm">
+										First, create some monitors to track your services.
+									</Paragraph>
+									<Button variant="primary" size="lg" href="/add-monitor">
+										Create a Monitor
+									</Button>
+								</Stack>
+							)}
+						</Stack>
+					</CardBody>
+				</Card>
+			</Section>
+		)}
 
-		<!-- Create First Page CTA -->
+		<!-- Features Section -->
 		<Section>
-			<Card>
-				<CardBody padding="xl">
-					<Stack align="center" gap="4">
-						<IconContainer variant="primary" size="lg">
-							<Icon icon="DASHBOARD" class="text-accent-primary" />
-						</IconContainer>
-						<Heading level={3}>Ready to go public?</Heading>
-						<Paragraph color="secondary" align="center">Create your first public status page and keep your users informed about your service status.</Paragraph>
-						<Button variant="primary" size="lg">
-							Create Status Page
-						</Button>
-					</Stack>
-				</CardBody>
-			</Card>
+			<Heading level={2} class="mb-4">Status Page Features</Heading>
+			<Grid cols="3" gap="4">
+				<Card>
+					<CardBody>
+						<Stack gap="2">
+							<Flex align="center" gap="2">
+								<Icon icon="GLOBAL" class="size-5 text-accent-primary" />
+								<Heading level={4}>Custom Domain</Heading>
+							</Flex>
+							<Paragraph color="secondary" class="text-sm">
+								Use your own domain for a branded status page experience.
+							</Paragraph>
+						</Stack>
+					</CardBody>
+				</Card>
+				<Card>
+					<CardBody>
+						<Stack gap="2">
+							<Flex align="center" gap="2">
+								<Icon icon="ANALYTICS" class="size-5 text-accent-primary" />
+								<Heading level={4}>Real-time Updates</Heading>
+							</Flex>
+							<Paragraph color="secondary" class="text-sm">
+								Status pages update automatically from your monitor data.
+							</Paragraph>
+						</Stack>
+					</CardBody>
+				</Card>
+				<Card>
+					<CardBody>
+						<Stack gap="2">
+							<Flex align="center" gap="2">
+								<Icon icon="DOCUMENT" class="size-5 text-accent-primary" />
+								<Heading level={4}>Incident Management</Heading>
+							</Flex>
+							<Paragraph color="secondary" class="text-sm">
+								Post updates during incidents to keep users informed.
+							</Paragraph>
+						</Stack>
+					</CardBody>
+				</Card>
+			</Grid>
 		</Section>
 		</Container>
 	</main>

--- a/apps/server/ARCHITECTURE.md
+++ b/apps/server/ARCHITECTURE.md
@@ -1,0 +1,701 @@
+# Uppe. Architecture - Decentralized Monitoring Network
+
+## Core Principle
+
+**Uppe. is a decentralized monitoring network where every peer strengthens the network.**
+
+- **All instances JOIN the decentralized network by default** - mobile phones, self-hosters, servers
+- **Self-hosters join the network** - they participate in and strengthen the decentralized network
+- **Rust Service (PeerUP/P2P) is self-contained** - each peer operates autonomously
+- **P2P Network is the core** - peers share monitoring results, strengthening the network
+- **Optional isolation** - can run without P2P (loses decentralized benefits, but still works locally)
+- **Go API is optional** - only needed when you want a local web frontend for data visibility
+- **No central authority** - each peer is equal and autonomous
+
+## Design Principles
+
+1. **Decentralized**: Every peer is autonomous and contributes to network strength
+2. **P2P-First**: Peer-to-peer communication is the core, not centralized APIs
+3. **Self-Contained Core**: Rust service (monitoring + P2P) works independently
+4. **Network Resilience**: More peers = stronger network (no single point of failure)
+5. **Optional Frontend API**: Go API is only for local frontend data visibility
+6. **Mobile-First**: Must run efficiently on mobile devices (battery, CPU, memory)
+7. **Zero-Config**: Easy deployment for thousands of peers
+8. **Scale Adaptive**: Works from single device to large clusters
+9. **Performance**: Minimal overhead, direct data access
+10. **Flexibility**: Support multiple deployment modes
+
+## Deployment Modes
+
+**All modes can join the decentralized P2P network - every peer strengthens the network, including mobile phones and self-hosters.**
+
+**Default: Join the network** - All instances participate in the decentralized monitoring network by default.
+**Optional: Isolated mode** - Can run without P2P (loses decentralized benefits).
+
+The only difference between modes is whether you want a local web frontend (Go API).
+
+### Mode 1: Rust Service Only (Decentralized Peer)
+
+**Self-contained Rust service - Perfect for mobile phones, full P2P network participation**
+
+```
+┌─────────────────────────────────────┐
+│     Rust Service (Decentralized Peer)│
+│  ┌──────────────────────────────┐  │
+│  │  Monitoring Engine            │  │
+│  │  - Reads monitors from DB     │  │
+│  │  - Performs checks            │  │
+│  │  - Writes results to DB       │  │
+│  └──────────────┬───────────────┘  │
+│                 │                   │
+│  ┌──────────────▼───────────────┐  │
+│  │  PeerUP P2P Network          │  │
+│  │  - Kademlia DHT              │  │
+│  │  - mDNS Discovery             │  │
+│  │  - Peer Communication          │  │
+│  │  - Shares results with peers   │  │
+│  │  - Receives results from peers │  │
+│  │  - Strengthens network         │  │
+│  └──────────────┬───────────────┘  │
+│                 │                   │
+│  ┌──────────────▼───────────────┐  │
+│  │  Embedded SQLite (libsql)    │  │
+│  │  - Zero external deps        │  │
+│  │  - Single file database       │  │
+│  │  - Direct read/write access   │  │
+│  │  - Stores local + peer data   │  │
+│  └──────────────────────────────┘  │
+└─────────────────────────────────────┘
+         │
+         │ P2P Network
+         │
+    ┌────┴────┐
+    │  Other  │
+    │  Peers  │
+    └─────────┘
+```
+
+**Characteristics:**
+- ✅ **Fully self-contained** - no external dependencies
+- ✅ **Full P2P network peer** - equal participant, strengthens network
+- ✅ **Mobile-friendly** - optimized for mobile phones (battery, CPU, memory)
+- ✅ **Shares monitoring results** - contributes to network resilience
+- ✅ **Receives peer results** - benefits from redundant monitoring
+- ✅ **Direct database access** - reads/writes directly
+- ✅ **Embedded SQLite** - zero external database needed
+- ✅ **Minimal resource usage** (~50-100 MB memory, perfect for mobile)
+- ✅ **Works offline** - can operate without internet (local monitoring)
+- ✅ **P2P networking** - full participation in decentralized network
+- ✅ **No API needed** - operates independently
+- ✅ **Network resilience** - more peers = stronger network
+
+**Network Participation:**
+- ✅ **Full peer** - mobile phones are equal peers in the network
+- ✅ **Monitors URLs** - assigned monitoring tasks
+- ✅ **Shares results** - cryptographically signed results shared peer-to-peer
+- ✅ **Receives results** - gets results from other peers (redundant monitoring)
+- ✅ **Strengthens network** - every peer makes the network more resilient
+- ✅ **No limitations** - mobile phones have full P2P capabilities
+
+**Use Cases:**
+- Mobile phones (primary use case - full network participation)
+- Raspberry Pi
+- Edge devices
+- Personal monitoring nodes
+- P2P network participants
+- Any device that wants to contribute to the network
+
+**Configuration:**
+```toml
+[mode]
+type = "standalone"  # Self-contained, no API
+
+[database]
+type = "libsql"
+path = "./uppe.db"
+
+[peerup]
+enabled = true
+# No API configuration needed
+```
+
+### Mode 2: Rust Service + Go API (Self-Hosted with Frontend)
+
+**Self-hosters JOIN the decentralized network (Rust) + Optional local frontend (Go API)**
+
+**Default: Joins the decentralized P2P network** - Self-hosters participate in the large monitoring network by default, strengthening it with their contribution.
+
+**Optional: Isolated mode** - Can run without P2P network (loses decentralized benefits, but still works locally).
+
+**Note: Rust service is a full peer in the P2P network by default, just like Mode 1. Go API is only for local frontend visibility.**
+
+```
+┌─────────────────┐         ┌─────────────────────────────┐
+│   Go API        │         │  Rust Service               │
+│   (apps/server) │         │ (Decentralized Peer)         │
+│                 │         │                             │
+│  - Local API    │         │  - Monitoring (self-contained)│
+│  - Data queries │         │  - P2P Network               │
+│  - Dashboards   │         │  - Shares results with peers │
+│  - Auth         │         │  - Direct DB writes          │
+│  (Local only)   │         │  - Strengthens network       │
+└────────┬────────┘         └────────┬────────────────────┘
+         │                           │
+         │  Reads from shared DB     │  Writes to shared DB
+         │                           │
+         └───────────┬───────────────┘
+                     │
+         ┌───────────▼───────────┐
+         │   Shared Database      │
+         │   - SQLite (small)     │
+         │   - PostgreSQL (large) │
+         │                         │
+         │  Rust: Read/Write       │
+         │  Go API: Read-only      │
+         └────────────────────────┘
+         │
+         │ P2P Network
+         │
+    ┌────┴────┐
+    │  Other  │
+    │  Peers  │
+    └─────────┘
+```
+
+**Characteristics:**
+- ✅ **Rust service is full P2P network peer** - operates independently, strengthens network
+- ✅ **Same P2P capabilities as Mode 1** - full network participation
+- ✅ **Go API is optional** - only for local frontend data visibility
+- ✅ **Shared database** - both read from same DB
+- ✅ **No coupling** - Rust service doesn't call Go API
+- ✅ **Direct database access** - no network overhead
+- ✅ **Full P2P network participation** - shares results with other peers
+- ✅ **Separation of concerns** - monitoring vs frontend
+
+**Data Flow:**
+- **Rust Service** (Full P2P Peer): 
+  - Reads monitors → Performs checks → Writes results (all direct DB)
+  - Shares results with peers via P2P network
+  - Receives results from peers via P2P network
+  - **Same network participation as Mode 1**
+- **Go API** (Local Frontend Only): 
+  - Reads monitors/results → Serves to local frontend (read-only DB access)
+  - Does not affect P2P network participation
+
+**Network Benefits:**
+- ✅ **Full peer** - participates in decentralized network (same as Mode 1)
+- ✅ **Shares results** - monitoring results shared with other peers
+- ✅ **Receives results** - gets results from other peers (redundant monitoring)
+- ✅ **Strengthens network** - contributes to network resilience
+- ✅ **Local visibility** - Go API provides local frontend (doesn't affect network)
+
+**Network Participation:**
+- ✅ **Joins decentralized network by default** - participates in large monitoring network
+- ✅ **Strengthens network** - contributes monitoring results to network
+- ✅ **Receives network benefits** - gets results from other peers (redundant monitoring)
+- ✅ **Full peer** - equal participant in decentralized network
+- ✅ **Optional isolation** - can disable P2P to run isolated (loses network benefits)
+
+**Use Cases:**
+- Self-hosted deployments with web UI (joins network by default)
+- Users who want dashboards and analytics
+- Medium-scale monitoring
+- Peers who want local visibility into their contribution
+- Users who want to strengthen the decentralized network
+
+**Configuration:**
+```toml
+# Go API (optional, only for frontend)
+[mode]
+type = "api-server"  # Frontend API only
+
+[database]
+type = "libsql"  # or "postgresql"
+path = "./uppe.db"  # Read-only access recommended
+
+# Rust Service (self-contained)
+[mode]
+type = "standalone"  # Self-contained, no API dependency
+
+[database]
+type = "libsql"
+path = "./uppe.db"  # Same path, read/write access
+```
+
+### Mode 3: Distributed Decentralized Network (Large Scale)
+
+**The decentralized network itself - all peers (mobile phones, self-hosters, servers) join this network**
+
+**This is the network that Mode 1 and Mode 2 peers join** - it's not a separate mode, it's the network itself.
+
+**Note: Every instance (Mode 1, Mode 2) joins this decentralized network by default. The network is made up of all participating peers.**
+
+```
+┌─────────────────┐
+│  Rust Service   │───P2P Network───┐
+│  (Peer 1)       │                  │
+│  - Decentralized│                  │
+│  - Direct DB    │                  │
+│  - Strengthens   │                  │
+│    network      │                  │
+└────────┬────────┘                  │
+         │                            │
+         │  Direct DB Access          │
+         │                            │
+┌────────▼────────┐                  │
+│  Local DB (Peer 1)│                  │
+└─────────────────┘                  │
+                                     │
+┌─────────────────┐                  │
+│  Rust Service   │───P2P Network───┤
+│  (Peer 2)       │                  │
+│  - Decentralized│                  │
+│  - Direct DB    │                  │
+│  - Strengthens   │                  │
+│    network      │                  │
+└────────┬────────┘                  │
+         │                            │
+         │  Direct DB Access          │
+         │                            │
+┌────────▼────────┐                  │
+│  Local DB (Peer 2)│                  │
+└─────────────────┘                  │
+                                     │
+┌─────────────────┐                  │
+│  Rust Service   │───P2P Network───┤
+│  (Peer N)       │                  │
+│  - Decentralized│                  │
+│  - Direct DB    │                  │
+│  - Strengthens   │                  │
+│    network      │                  │
+└────────┬────────┘                  │
+         │                            │
+         │  Direct DB Access          │
+         │                            │
+┌────────▼────────┐                  │
+│  Local DB (Peer N)│                  │
+└─────────────────┘                  │
+                                     │
+                    ┌─────────────────┴──────────────┐
+                    │   Go API Server (Optional)     │
+                    │   (apps/server)                │
+                    │  - Aggregates from P2P network │
+                    │  - Serves frontend              │
+                    │  - Auth & Rate limiting         │
+                    └───────────┬────────────────────┘
+                                │
+                    ┌───────────▼───────────┐
+                    │   Aggregation DB      │
+                    │   PostgreSQL/TimescaleDB│
+                    │   - Aggregated data     │
+                    │   - Time-series optimized│
+                    │   (Optional, for UI)    │
+                    └────────────────────────┘
+```
+
+**Characteristics:**
+- ✅ **Each Rust service is a full P2P network peer** - operates independently
+- ✅ **Same P2P capabilities as Mode 1 & 2** - full network participation per peer
+- ✅ **P2P network is the core** - peers communicate peer-to-peer
+- ✅ **Local databases** - each peer has its own DB
+- ✅ **Network strength** - more peers = stronger, more resilient network
+- ✅ **No central authority** - all peers are equal (mobile phones = servers = equal)
+- ✅ **Go API is optional** - aggregates data for frontend (not required for network)
+- ✅ **Horizontally scalable** - add more peers (mobile phones, servers, etc.) to strengthen network
+- ✅ **Best for high throughput** - distributed monitoring
+- ✅ **All peers equal** - mobile phones participate same as servers
+
+**Data Flow:**
+- **Rust Services (Full P2P Peers)**: 
+  - Each operates independently, writes to local DB
+  - Monitors assigned URLs
+  - Shares results with peers via P2P network
+  - Receives results from peers via P2P network
+  - Strengthens network with each contribution
+  - **Same network participation regardless of device** (mobile phone = server = equal peer)
+- **P2P Network**: 
+  - Decentralized communication between peers
+  - All peers are equal (mobile phones, servers, edge devices)
+  - Cryptographically signed results
+  - Redundant monitoring (multiple peers monitor same URLs)
+  - No single point of failure
+  - Network strength grows with each peer (including mobile phones)
+- **Go API (Optional)**: 
+  - Aggregates data from P2P network for frontend
+  - Not required for network operation
+  - Provides centralized view of decentralized data
+  - Does not affect peer participation
+
+**Network Benefits:**
+- **Decentralized**: No single point of failure
+- **Resilient**: Network strength grows with each peer (including mobile phones)
+- **Redundant**: Multiple peers monitor same URLs
+- **Trust**: Cryptographically signed results
+- **Scalable**: Add peers (mobile phones, servers, edge devices) to strengthen network
+- **Equal Participation**: All devices are equal peers (mobile phones = servers)
+
+**Use Cases:**
+- Large-scale decentralized monitoring network
+- Hosted Uppe. product (aggregation layer)
+- Multi-region deployments
+- Enterprise customers with many peers
+- Community-driven monitoring networks
+
+**Configuration:**
+```toml
+# Go API (frontend aggregator)
+[mode]
+type = "api-server"
+
+[database]
+type = "postgresql"
+url = "postgresql://..."  # Centralized aggregation DB
+
+# Rust Service (each node, self-contained)
+[mode]
+type = "standalone"  # Self-contained, no API dependency
+
+[database]
+type = "libsql"  # or "postgresql"
+path = "./uppe-node-1.db"  # Local DB per node
+
+[peerup]
+enabled = true
+# P2P network for peer communication
+```
+
+## Recommended Architecture: Decentralized P2P Core
+
+**All Rust services JOIN the decentralized P2P network by default - they strengthen the network, regardless of device type (mobile phones, self-hosters, servers, edge devices):**
+
+```rust
+// Rust service is a decentralized peer
+// It reads/writes directly to database
+// It participates in P2P network
+// No API calls needed for core functionality
+
+// Rust service startup logic
+let db = open_database(&config.database_path).await?;
+
+// Read monitors directly from DB
+let monitors = db.get_enabled_monitors().await?;
+
+// Perform monitoring checks
+for monitor in monitors {
+    let result = check_monitor(&monitor).await?;
+    // Write result directly to DB
+    db.save_result(&result).await?;
+    
+    // Share result with peers via P2P network
+    // This strengthens the network
+    p2p_network.share_result(&result).await?;
+}
+
+// P2P networking (default: join decentralized network)
+// All instances join the network by default
+if config.peerup.enabled {
+    let p2p_network = start_p2p_network().await?;
+    
+    // Join the decentralized monitoring network
+    // Self-hosters, mobile phones, servers - all join the same network
+    p2p_network.join_network().await?;
+    
+    // Listen for results from other peers
+    // Each peer strengthens the network (mobile phones = self-hosters = servers = equal)
+    p2p_network.on_peer_result(|result| {
+        // Store peer results (redundant monitoring)
+        db.save_peer_result(&result).await?;
+    });
+    
+    // Share our results with peers
+    // All instances contribute to network strength
+    p2p_network.share_result(&result).await?;
+} else {
+    // Optional: Isolated mode (no network participation)
+    // Loses decentralized benefits but still works locally
+    log::info!("Running in isolated mode (no P2P network)");
+}
+```
+
+**Go API is optional and independent - only for local frontend:**
+
+```go
+// Go API only reads from database for frontend
+// It doesn't control Rust service
+// It doesn't control the network
+// It's purely for local data visibility
+
+// Go API startup logic
+db := open_database(&config.database_path)
+
+// Serve frontend API
+// - List monitors (read from DB)
+// - Get results (read from DB, includes peer results)
+// - Aggregations (read from DB)
+// - No writes (Rust service handles all writes)
+// - No network control (P2P network is autonomous)
+```
+
+## Database Access Strategy
+
+### Rust Service (Always Self-Contained)
+- **Direct database access** (always)
+- **Read monitors** from DB
+- **Write results** to DB
+- **No API calls** for core functionality
+- **Works offline** (no network dependency)
+
+### Go API (Frontend Only)
+- **Read-only database access** (recommended)
+- **Read monitors** for display
+- **Read results** for dashboards
+- **Aggregations** for analytics
+- **No writes** (Rust service handles all writes)
+
+### Shared Database (Mode 2)
+- **SQLite WAL mode** for concurrent reads/writes
+- **Rust service**: Read/Write access
+- **Go API**: Read-only access (recommended)
+- **Connection pooling** in both services
+
+## Performance Optimizations
+
+### Mobile/Standalone
+1. **Embedded SQLite** - Zero network overhead
+2. **Lightweight HTTP server** - Minimal memory footprint
+3. **Batch writes** - Group result writes to reduce I/O
+4. **Connection pooling** - Reuse database connections
+5. **WAL mode** - Better concurrency for SQLite
+
+### Self-Hosted
+1. **Shared database** - Direct access, no HTTP overhead
+2. **SQLite WAL mode** - Concurrent reads/writes
+3. **Connection pooling** - Both services use pools
+4. **Batch inserts** - Group result writes
+
+### Large Scale
+1. **PostgreSQL/TimescaleDB** - Better concurrency than SQLite
+2. **Connection pooling** - Essential for performance
+3. **Read replicas** - Scale reads independently
+4. **Batch API calls** - Group monitor fetches
+5. **Caching** - Cache monitors in Rust service
+
+## Implementation Plan
+
+### Phase 1: Self-Contained Rust Service (Mobile Support) - PRIORITY
+
+**Rust Service (Core Functionality):**
+1. ✅ Direct database access (already implemented)
+2. ✅ Read monitors from DB (implement)
+3. ✅ Write results to DB (implement)
+4. ✅ P2P networking (PeerUP integration)
+5. ✅ No API dependency (fully self-contained)
+
+**Benefits:**
+- ✅ Mobile phone support
+- ✅ Zero external dependencies
+- ✅ Works offline
+- ✅ Minimal resource usage
+- ✅ Fully autonomous
+
+### Phase 2: Optional Go API (Frontend Support)
+
+**Go API (Frontend Only):**
+1. ✅ Read-only database access (recommended)
+2. ✅ Serve frontend API endpoints
+3. ✅ Data aggregations for dashboards
+4. ✅ Authentication/authorization
+5. ✅ No control over Rust service (independent)
+
+**Shared Database:**
+1. Ensure both services can use same database path
+2. Coordinate startup so Rust runs migrations first and Go verifies schema compatibility
+3. SQLite WAL mode for concurrent access
+4. Test concurrent reads/writes
+
+### Phase 3: Distributed Mode (Large Scale)
+
+**Enhancements:**
+1. P2P result sharing between Rust services
+2. Go API aggregates from multiple nodes
+3. Centralized aggregation database (optional)
+4. Multi-region support
+
+## Configuration Examples
+
+### Mobile Phone (Joins Network)
+```toml
+# Rust Service - Joins decentralized network by default
+[mode]
+type = "standalone"
+
+[database]
+type = "libsql"
+path = "./uppe.db"
+
+[peerup]
+enabled = true  # Default: joins decentralized network
+# Optional: set to false for isolated mode (loses network benefits)
+
+[monitoring]
+enabled = true
+# No API configuration - fully self-contained
+```
+
+### Self-Hosted (Joins Network + Local Frontend)
+```toml
+# Rust Service - Joins decentralized network by default
+[mode]
+type = "standalone"
+
+[database]
+type = "libsql"
+path = "/var/lib/uppe/uppe.db"
+
+[peerup]
+enabled = true  # Default: joins decentralized network
+# Optional: set to false for isolated mode (loses network benefits)
+
+# Go API - Frontend only (optional)
+[mode]
+type = "api-server"
+
+[database]
+type = "libsql"
+path = "/var/lib/uppe/uppe.db"  # Same path, read-only recommended
+
+[server]
+address = "0.0.0.0:8080"
+```
+
+### Isolated Mode (No Network - Optional)
+```toml
+# Rust Service - Isolated mode (no P2P network)
+[mode]
+type = "standalone"
+
+[database]
+type = "libsql"
+path = "./uppe.db"
+
+[peerup]
+enabled = false  # Isolated mode - no network participation
+# Loses decentralized benefits but still works locally
+
+[monitoring]
+enabled = true
+```
+
+### Large Scale (Network Itself)
+```toml
+# All peers (mobile, self-hosted, servers) join this network
+# This is the decentralized network configuration
+# Each peer uses same P2P network settings
+
+[peerup]
+network_id = "uppe-mainnet"  # All peers join same network
+bootstrap_nodes = ["..."]  # Network bootstrap nodes
+enabled = true  # Default for all peers
+```
+
+## Migration Path
+
+1. **Start with Standalone** - Get mobile support working
+2. **Add Split Mode** - Enable self-hosted deployments
+3. **Add Distributed Mode** - Scale to large deployments
+
+## Resource Usage Estimates
+
+### Mobile Phone (Standalone)
+- **Memory**: ~50-100 MB
+- **CPU**: < 5% (idle), 10-20% (active monitoring)
+- **Battery**: Minimal impact (efficient polling)
+- **Storage**: ~10-50 MB (database + binary)
+
+### Self-Hosted (Split)
+- **Go API**: ~100-200 MB memory
+- **Rust Service**: ~50-100 MB memory
+- **Database**: Depends on data size
+- **Total**: ~200-400 MB
+
+### Large Scale (Distributed)
+- **Go API**: ~500 MB - 2 GB (with caching)
+- **Rust Service**: ~100-200 MB per node
+- **Database**: Depends on scale (PostgreSQL cluster)
+
+## Recommendations
+
+### For Mobile Phones: **Rust Service Only (Mode 1) - Full P2P Network Peer**
+- ✅ **Full P2P network peer** - equal participant, contributes to network strength
+- ✅ **Same capabilities as servers** - mobile phones are equal peers
+- ✅ Self-contained Rust service
+- ✅ Embedded SQLite
+- ✅ Zero external dependencies
+- ✅ No API needed (fully autonomous)
+- ✅ **Full P2P networking** - shares results, receives results, strengthens network
+- ✅ Minimal resource usage (~50-100 MB)
+- ✅ Works offline (local monitoring)
+- ✅ **Network resilience** - mobile phones strengthen the network just like servers
+
+### For Self-Hosters: **Rust Service + Go API (Mode 2) - Joins Network + Local UI**
+- ✅ **JOINS decentralized network by default** - participates in large monitoring network
+- ✅ **Full P2P network peer** - equal participant, contributes to network strength
+- ✅ **Same P2P capabilities as Mode 1** - full network participation
+- ✅ **Strengthens network** - contributes monitoring results to decentralized network
+- ✅ **Receives network benefits** - gets results from other peers (redundant monitoring)
+- ✅ Self-contained Rust service (core functionality)
+- ✅ **Full P2P networking** - shares results, receives results, strengthens network
+- ✅ Optional Go API (only for local frontend)
+- ✅ Optional isolation mode (can disable P2P, loses network benefits)
+- ✅ Shared SQLite (small) or PostgreSQL (large)
+- ✅ Direct database access (no API overhead)
+- ✅ Easy deployment
+- ✅ Rust service operates independently
+
+### The Decentralized Network: **All Modes Join (Mode 3) - The Network Itself**
+- ✅ **All instances join by default** - mobile phones, self-hosters, servers
+- ✅ **All peers are equal** - mobile phones = self-hosters = servers = edge devices
+- ✅ P2P network is the core (no central authority)
+- ✅ Each peer is autonomous and equal (same capabilities)
+- ✅ Network resilience grows with each peer (including mobile phones and self-hosters)
+- ✅ Redundant monitoring (multiple peers monitor same URLs)
+- ✅ Self-hosters strengthen the network by joining
+- ✅ Mobile phones strengthen the network by joining
+- ✅ Optional Go API aggregates data for frontend (some peers)
+- ✅ PostgreSQL/TimescaleDB for aggregations (optional, some peers)
+- ✅ Horizontally scalable (add any device as peer to strengthen network)
+
+## Next Steps
+
+1. **Complete Full P2P Network Peer (Rust Service)** (Priority)
+   - ✅ Direct database access (already implemented)
+   - Implement monitor reading from DB
+   - Implement result writing to DB
+   - Integrate PeerUP P2P networking
+   - **Full network participation** - share results with peers (strengthen network)
+   - **Full network participation** - receive results from peers (redundant monitoring)
+   - **Works on all devices** - mobile phones, servers, edge devices (all equal peers)
+   - No API dependency (fully autonomous peer)
+   - **Mobile-optimized** - efficient P2P networking for mobile devices
+
+2. **Ensure Go API works independently**
+   - Read-only database access (recommended)
+   - Frontend API endpoints
+   - Data aggregations (local + peer results)
+   - No control over Rust service or network
+   - Optional component (network works without it)
+
+3. **Test Shared Database Access**
+   - SQLite WAL mode for concurrency
+   - Rust: Read/Write, Go API: Read-only
+   - Coordinate migrations
+   - Test concurrent access
+
+4. **Enhance P2P Network (All Devices)**
+   - Cryptographically signed results
+   - Result sharing between peers (all devices equal)
+   - Redundant monitoring coordination
+   - Network strength metrics
+   - Peer discovery and communication
+   - **Mobile optimization** - efficient P2P for mobile devices (battery, bandwidth)
+   - **Equal participation** - mobile phones have same P2P capabilities as servers

--- a/apps/server/DATABASE_SHARING.md
+++ b/apps/server/DATABASE_SHARING.md
@@ -1,0 +1,61 @@
+# Database Sharing
+
+## Current Rule
+
+The Rust service owns the database schema.
+
+Canonical schema source:
+
+- [apps/service/src/database/migrations.rs](/home/crunchy/dev/Obiente/Uppe/apps/service/src/database/migrations.rs)
+
+Go API behavior:
+
+- verifies schema compatibility on startup
+- reads and writes user-facing data against the Rust-owned schema
+- does not run migrations
+- does not define a competing executable schema
+
+Schema documentation:
+
+- [shared/database/schema.sql](/home/crunchy/dev/Obiente/Uppe/shared/database/schema.sql)
+
+That file is documentation only. It must not be treated as the executable authority over the Rust migrations.
+
+## Shared Database Model
+
+The intended deployment model is:
+
+- Rust service and Go API point at the same SQLite/LibSQL database
+- Rust initializes and migrates the schema
+- Go waits for the schema to exist and verifies compatibility
+- frontend talks only to the Go API
+
+## Startup Order
+
+1. Start the Rust service first.
+2. Let the Rust service create or migrate the schema.
+3. Start the Go API.
+4. The Go API verifies schema compatibility and serves frontend/API clients.
+
+## Why
+
+This keeps one schema owner and avoids:
+
+- migration drift
+- conflicting table definitions
+- multiple executable schema sources
+
+## What Not To Do
+
+Do not:
+
+- run migrations from the Go server
+- reintroduce an active Go-owned migration directory
+- treat an old SQL snapshot as the real schema when Rust migrations differ
+
+## Follow-Up Work
+
+The longer-term cleanup is:
+
+- remove obsolete Go migration helpers entirely
+- generate schema docs from Rust migration state or keep them explicitly documentation-only

--- a/apps/server/internal/connect/network/network.go
+++ b/apps/server/internal/connect/network/network.go
@@ -1,0 +1,190 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+	"go.uber.org/zap"
+
+	commonv1 "github.com/Obiente/Uppe/apps/server/gen/common/v1"
+	networkv1 "github.com/Obiente/Uppe/apps/server/gen/network/v1"
+	"github.com/Obiente/Uppe/apps/server/gen/network/v1/networkv1connect"
+	"github.com/Obiente/Uppe/apps/server/internal/db"
+	dbtypes "github.com/Obiente/Uppe/apps/server/internal/db/types"
+	"github.com/Obiente/Uppe/apps/server/internal/models"
+)
+
+type NetworkService struct {
+	logger   *zap.Logger
+	database db.Database
+}
+
+var _ networkv1connect.NetworkServiceHandler = (*NetworkService)(nil)
+
+func NewNetworkService(logger *zap.Logger, database db.Database) *NetworkService {
+	return &NetworkService{
+		logger:   logger,
+		database: database,
+	}
+}
+
+func (s *NetworkService) GetNetworkStats(
+	ctx context.Context,
+	_ *connect.Request[networkv1.GetNetworkStatsRequest],
+) (*connect.Response[networkv1.NetworkStats], error) {
+	stats, err := s.database.GetNetworkStats(ctx)
+	if err != nil {
+		s.logger.Error("Failed to load network stats", zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load network stats: %w", err))
+	}
+
+	return connect.NewResponse(&networkv1.NetworkStats{
+		TotalPeers:           stats.TotalPeers,
+		OnlinePeers:          stats.OnlinePeers,
+		ChecksPerHour:        stats.ChecksPerHour,
+		CoveragePercentage:   stats.CoveragePercentage,
+		ShareRatio:           stats.ShareRatio,
+		MonitoringForOthers:  stats.MonitoringForOthers,
+		ReceivingFromOthers:  stats.ReceivingFromOthers,
+		ContributionScore:    stats.ContributionScore,
+		MyNodeId:             stats.MyNodeID,
+		BandwidthUsedMb:      stats.BandwidthUsedMb,
+		BandwidthLimitMb:     stats.BandwidthLimitMb,
+		ChecksPerformedToday: stats.ChecksPerformedToday,
+		ChecksReceivedToday:  stats.ChecksReceivedToday,
+	}), nil
+}
+
+func (s *NetworkService) ListPeers(
+	ctx context.Context,
+	req *connect.Request[networkv1.ListPeersRequest],
+) (*connect.Response[networkv1.ListPeersResponse], error) {
+	filterStatus := ""
+	if req.Msg.FilterStatus != networkv1.PeerStatus_PEER_STATUS_UNSPECIFIED {
+		filterStatus = peerStatusToDB(req.Msg.FilterStatus)
+	}
+
+	peers, total, err := s.database.ListPeers(ctx, &dbtypes.PeerQuery{
+		Page:         int(req.Msg.Page),
+		PageSize:     int(req.Msg.PageSize),
+		SortBy:       req.Msg.SortBy,
+		FilterStatus: filterStatus,
+	})
+	if err != nil {
+		s.logger.Error("Failed to list peers", zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to list peers: %w", err))
+	}
+
+	response := &networkv1.ListPeersResponse{
+		Peers:    make([]*networkv1.Peer, 0, len(peers)),
+		Total:    int32(total),
+		Page:     req.Msg.Page,
+		PageSize: req.Msg.PageSize,
+	}
+	for _, peer := range peers {
+		response.Peers = append(response.Peers, peerToProto(peer))
+	}
+
+	return connect.NewResponse(response), nil
+}
+
+func (s *NetworkService) GetPeer(
+	ctx context.Context,
+	req *connect.Request[networkv1.GetPeerRequest],
+) (*connect.Response[networkv1.Peer], error) {
+	peer, err := s.database.GetPeer(ctx, req.Msg.PeerId)
+	if err != nil {
+		s.logger.Error("Failed to load peer", zap.String("peer_id", req.Msg.PeerId), zap.Error(err))
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("failed to load peer: %w", err))
+	}
+
+	return connect.NewResponse(peerToProto(peer)), nil
+}
+
+func (s *NetworkService) GetNetworkHealth(
+	ctx context.Context,
+	_ *connect.Request[networkv1.GetNetworkHealthRequest],
+) (*connect.Response[networkv1.NetworkHealth], error) {
+	health, err := s.database.GetNetworkHealth(ctx)
+	if err != nil {
+		s.logger.Error("Failed to load network health", zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load network health: %w", err))
+	}
+
+	return connect.NewResponse(&networkv1.NetworkHealth{
+		ConsensusRate:    health.ConsensusRate,
+		AvgLatencyMs:     health.AvgLatencyMs,
+		RedundancyFactor: health.RedundancyFactor,
+		ChurnRate:        health.ChurnRate,
+	}), nil
+}
+
+func (s *NetworkService) GetPeerDistribution(
+	ctx context.Context,
+	_ *connect.Request[networkv1.GetPeerDistributionRequest],
+) (*connect.Response[networkv1.PeerDistribution], error) {
+	regions, err := s.database.GetPeerDistribution(ctx)
+	if err != nil {
+		s.logger.Error("Failed to load peer distribution", zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load peer distribution: %w", err))
+	}
+
+	response := &networkv1.PeerDistribution{
+		Regions: make([]*networkv1.RegionStats, 0, len(regions)),
+	}
+	for _, region := range regions {
+		response.Regions = append(response.Regions, &networkv1.RegionStats{
+			Region:       region.Region,
+			PeerCount:    region.PeerCount,
+			OnlineCount:  region.OnlineCount,
+			AvgLatencyMs: region.AvgLatencyMs,
+		})
+	}
+	return connect.NewResponse(response), nil
+}
+
+func peerToProto(peer *models.NetworkPeer) *networkv1.Peer {
+	location := peer.Location
+	if location == nil {
+		location = &commonv1.Location{}
+	}
+
+	return &networkv1.Peer{
+		PeerId:            peer.PeerID,
+		Location:          location,
+		Status:            peerStatusFromDB(peer.Status),
+		ChecksPerDay:      peer.ChecksPerDay,
+		LastSeen:          peer.LastSeen.Unix(),
+		UptimePercentage:  peer.UptimePercentage,
+		ContributionScore: peer.ContributionScore,
+		JoinedAt:          peer.JoinedAt.Unix(),
+	}
+}
+
+func peerStatusFromDB(status string) networkv1.PeerStatus {
+	switch strings.ToLower(status) {
+	case "online":
+		return networkv1.PeerStatus_PEER_STATUS_ONLINE
+	case "slow":
+		return networkv1.PeerStatus_PEER_STATUS_SLOW
+	case "offline":
+		return networkv1.PeerStatus_PEER_STATUS_OFFLINE
+	default:
+		return networkv1.PeerStatus_PEER_STATUS_UNSPECIFIED
+	}
+}
+
+func peerStatusToDB(status networkv1.PeerStatus) string {
+	switch status {
+	case networkv1.PeerStatus_PEER_STATUS_ONLINE:
+		return "online"
+	case networkv1.PeerStatus_PEER_STATUS_SLOW:
+		return "slow"
+	case networkv1.PeerStatus_PEER_STATUS_OFFLINE:
+		return "offline"
+	default:
+		return ""
+	}
+}

--- a/apps/server/internal/connect/settings/settings.go
+++ b/apps/server/internal/connect/settings/settings.go
@@ -1,0 +1,443 @@
+package settings
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"connectrpc.com/connect"
+	"go.uber.org/zap"
+
+	settingsv1 "github.com/Obiente/Uppe/apps/server/gen/settings/v1"
+	"github.com/Obiente/Uppe/apps/server/gen/settings/v1/settingsv1connect"
+	"github.com/Obiente/Uppe/apps/server/internal/db"
+)
+
+type SettingsService struct {
+	logger   *zap.Logger
+	database db.Database
+}
+
+var _ settingsv1connect.SettingsServiceHandler = (*SettingsService)(nil)
+
+func NewSettingsService(logger *zap.Logger, database db.Database) *SettingsService {
+	return &SettingsService{
+		logger:   logger,
+		database: database,
+	}
+}
+
+func (s *SettingsService) GetSettings(
+	ctx context.Context,
+	_ *connect.Request[settingsv1.GetSettingsRequest],
+) (*connect.Response[settingsv1.Settings], error) {
+	settings, err := s.loadSettings(ctx)
+	if err != nil {
+		s.logger.Error("Failed to load settings", zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load settings: %w", err))
+	}
+
+	return connect.NewResponse(settings), nil
+}
+
+func (s *SettingsService) UpdateSettings(
+	ctx context.Context,
+	req *connect.Request[settingsv1.UpdateSettingsRequest],
+) (*connect.Response[settingsv1.Settings], error) {
+	if req.Msg.Settings == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("settings payload is required"))
+	}
+
+	if err := s.storeSettings(ctx, req.Msg.Settings); err != nil {
+		s.logger.Error("Failed to update settings", zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to update settings: %w", err))
+	}
+
+	settings, err := s.loadSettings(ctx)
+	if err != nil {
+		s.logger.Error("Failed to reload settings", zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to reload settings: %w", err))
+	}
+
+	return connect.NewResponse(settings), nil
+}
+
+func (s *SettingsService) GetNodeIdentity(
+	ctx context.Context,
+	_ *connect.Request[settingsv1.GetNodeIdentityRequest],
+) (*connect.Response[settingsv1.NodeIdentity], error) {
+	identity, err := s.database.GetNodeIdentity(ctx)
+	if err != nil {
+		s.logger.Error("Failed to load node identity", zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load node identity: %w", err))
+	}
+
+	return connect.NewResponse(&settingsv1.NodeIdentity{
+		NodeId:               identity.NodeID,
+		NodeName:             identity.NodeName,
+		JoinedNetworkAt:      identity.JoinedNetworkAt.Unix(),
+		ContributionScore:    identity.ContributionScore,
+		TotalChecksPerformed: identity.TotalChecksPerformed,
+		TotalChecksReceived:  identity.TotalChecksReceived,
+	}), nil
+}
+
+func (s *SettingsService) loadSettings(ctx context.Context) (*settingsv1.Settings, error) {
+	getString := func(key, def string) (string, error) {
+		v, ok, err := s.database.GetSetting(ctx, key)
+		if err != nil {
+			return "", err
+		}
+		if !ok || v == "" {
+			return def, nil
+		}
+		return v, nil
+	}
+
+	getBool := func(key string, def bool) (bool, error) {
+		v, ok, err := s.database.GetSetting(ctx, key)
+		if err != nil {
+			return false, err
+		}
+		if !ok || v == "" {
+			return def, nil
+		}
+		b, parseErr := strconv.ParseBool(v)
+		if parseErr != nil {
+			return def, nil
+		}
+		return b, nil
+	}
+
+	getInt32 := func(key string, def int32) (int32, error) {
+		v, ok, err := s.database.GetSetting(ctx, key)
+		if err != nil {
+			return 0, err
+		}
+		if !ok || v == "" {
+			return def, nil
+		}
+		n, parseErr := strconv.Atoi(v)
+		if parseErr != nil {
+			return def, nil
+		}
+		return int32(n), nil
+	}
+
+	getInt64 := func(key string, def int64) (int64, error) {
+		v, ok, err := s.database.GetSetting(ctx, key)
+		if err != nil {
+			return 0, err
+		}
+		if !ok || v == "" {
+			return def, nil
+		}
+		n, parseErr := strconv.ParseInt(v, 10, 64)
+		if parseErr != nil {
+			return def, nil
+		}
+		return n, nil
+	}
+
+	getFloat64 := func(key string, def float64) (float64, error) {
+		v, ok, err := s.database.GetSetting(ctx, key)
+		if err != nil {
+			return 0, err
+		}
+		if !ok || v == "" {
+			return def, nil
+		}
+		n, parseErr := strconv.ParseFloat(v, 64)
+		if parseErr != nil {
+			return def, nil
+		}
+		return n, nil
+	}
+
+	getStringArray := func(key string) ([]string, error) {
+		v, ok, err := s.database.GetSetting(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		if !ok || v == "" {
+			return []string{}, nil
+		}
+		var values []string
+		if err := json.Unmarshal([]byte(v), &values); err != nil {
+			return []string{}, nil
+		}
+		return values, nil
+	}
+
+	displayName, err := getString("display_name", "Uppe. Node")
+	if err != nil {
+		return nil, err
+	}
+	email, err := getString("email", "")
+	if err != nil {
+		return nil, err
+	}
+	timezone, err := getString("timezone", "UTC")
+	if err != nil {
+		return nil, err
+	}
+
+	emailNotifications, err := getBool("email_notifications", true)
+	if err != nil {
+		return nil, err
+	}
+	incidentReports, err := getBool("incident_reports", false)
+	if err != nil {
+		return nil, err
+	}
+	networkUpdates, err := getBool("network_updates", true)
+	if err != nil {
+		return nil, err
+	}
+
+	discoveryMethodRaw, err := getString("discovery_method", "dht_and_bootstrap")
+	if err != nil {
+		return nil, err
+	}
+	contributeToNetwork, err := getBool("contribute_to_network", true)
+	if err != nil {
+		return nil, err
+	}
+	maxBandwidth, err := getInt64("max_bandwidth_mb_per_day", 100)
+	if err != nil {
+		return nil, err
+	}
+	maxConcurrentChecks, err := getInt32("max_concurrent_checks", 50)
+	if err != nil {
+		return nil, err
+	}
+	autoAcceptRequests, err := getBool("auto_accept_requests", true)
+	if err != nil {
+		return nil, err
+	}
+	bootstrapNodes, err := getStringArray("bootstrap_nodes")
+	if err != nil {
+		return nil, err
+	}
+	manualPeers, err := getStringArray("manual_peers")
+	if err != nil {
+		return nil, err
+	}
+
+	defaultInterval, err := getInt32("default_interval_seconds", 60)
+	if err != nil {
+		return nil, err
+	}
+	defaultTimeout, err := getInt32("default_timeout_seconds", 10)
+	if err != nil {
+		return nil, err
+	}
+	detailedLogging, err := getBool("detailed_logging", false)
+	if err != nil {
+		return nil, err
+	}
+	retentionDays, err := getInt32("result_retention_days", 30)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterName, err := getString("cluster_name", "My Cluster")
+	if err != nil {
+		return nil, err
+	}
+	clusterPublic, err := getBool("cluster_is_public", true)
+	if err != nil {
+		return nil, err
+	}
+	maxClusterSize, err := getInt32("cluster_max_size", 25)
+	if err != nil {
+		return nil, err
+	}
+	joinPolicyRaw, err := getString("cluster_join_policy", "open")
+	if err != nil {
+		return nil, err
+	}
+	minContributionScore, err := getFloat64("cluster_min_contribution_score", 1.5)
+	if err != nil {
+		return nil, err
+	}
+
+	return &settingsv1.Settings{
+		Account: &settingsv1.AccountSettings{
+			DisplayName: displayName,
+			Email:       email,
+			Timezone:    timezone,
+		},
+		Notifications: &settingsv1.NotificationSettings{
+			EmailNotifications:           emailNotifications,
+			IncidentReports:              incidentReports,
+			NetworkUpdates:               networkUpdates,
+			DowntimeAlertThresholdSeconds: 300,
+			LatencyAlertThresholdMs:      1000,
+		},
+		Network: &settingsv1.NetworkSettings{
+			DiscoveryMethod:   mapDiscoveryMethod(discoveryMethodRaw),
+			ContributeToNetwork: contributeToNetwork,
+			MaxBandwidthMbPerDay: maxBandwidth,
+			MaxConcurrentChecks: maxConcurrentChecks,
+			AutoAcceptRequests: autoAcceptRequests,
+			BootstrapNodes:     bootstrapNodes,
+			ManualPeers:        manualPeers,
+		},
+		Monitoring: &settingsv1.MonitoringSettings{
+			DefaultIntervalSeconds: defaultInterval,
+			DefaultTimeoutSeconds:  defaultTimeout,
+			DetailedLogging:        detailedLogging,
+			ResultRetentionDays:    retentionDays,
+		},
+		Cluster: &settingsv1.ClusterSettings{
+			ClusterName:          clusterName,
+			IsPublic:             clusterPublic,
+			MaxClusterSize:       maxClusterSize,
+			JoinPolicy:           mapJoinPolicy(joinPolicyRaw),
+			MinContributionScore: minContributionScore,
+		},
+	}, nil
+}
+
+func (s *SettingsService) storeSettings(ctx context.Context, settings *settingsv1.Settings) error {
+	if settings.Account != nil {
+		if err := s.database.SetSetting(ctx, "display_name", settings.Account.DisplayName); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "email", settings.Account.Email); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "timezone", settings.Account.Timezone); err != nil {
+			return err
+		}
+	}
+
+	if settings.Notifications != nil {
+		if err := s.database.SetSetting(ctx, "email_notifications", strconv.FormatBool(settings.Notifications.EmailNotifications)); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "incident_reports", strconv.FormatBool(settings.Notifications.IncidentReports)); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "network_updates", strconv.FormatBool(settings.Notifications.NetworkUpdates)); err != nil {
+			return err
+		}
+	}
+
+	if settings.Network != nil {
+		if err := s.database.SetSetting(ctx, "discovery_method", unmapDiscoveryMethod(settings.Network.DiscoveryMethod)); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "contribute_to_network", strconv.FormatBool(settings.Network.ContributeToNetwork)); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "max_bandwidth_mb_per_day", strconv.FormatInt(settings.Network.MaxBandwidthMbPerDay, 10)); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "max_concurrent_checks", strconv.FormatInt(int64(settings.Network.MaxConcurrentChecks), 10)); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "auto_accept_requests", strconv.FormatBool(settings.Network.AutoAcceptRequests)); err != nil {
+			return err
+		}
+		if err := setStringArray(ctx, s.database, "bootstrap_nodes", settings.Network.BootstrapNodes); err != nil {
+			return err
+		}
+		if err := setStringArray(ctx, s.database, "manual_peers", settings.Network.ManualPeers); err != nil {
+			return err
+		}
+	}
+
+	if settings.Monitoring != nil {
+		if err := s.database.SetSetting(ctx, "default_interval_seconds", strconv.FormatInt(int64(settings.Monitoring.DefaultIntervalSeconds), 10)); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "default_timeout_seconds", strconv.FormatInt(int64(settings.Monitoring.DefaultTimeoutSeconds), 10)); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "detailed_logging", strconv.FormatBool(settings.Monitoring.DetailedLogging)); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "result_retention_days", strconv.FormatInt(int64(settings.Monitoring.ResultRetentionDays), 10)); err != nil {
+			return err
+		}
+	}
+
+	if settings.Cluster != nil {
+		if err := s.database.SetSetting(ctx, "cluster_name", settings.Cluster.ClusterName); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "cluster_is_public", strconv.FormatBool(settings.Cluster.IsPublic)); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "cluster_max_size", strconv.FormatInt(int64(settings.Cluster.MaxClusterSize), 10)); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "cluster_join_policy", unmapJoinPolicy(settings.Cluster.JoinPolicy)); err != nil {
+			return err
+		}
+		if err := s.database.SetSetting(ctx, "cluster_min_contribution_score", strconv.FormatFloat(settings.Cluster.MinContributionScore, 'f', -1, 64)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func setStringArray(ctx context.Context, database db.Database, key string, values []string) error {
+	data, err := json.Marshal(values)
+	if err != nil {
+		return err
+	}
+	return database.SetSetting(ctx, key, string(data))
+}
+
+func mapDiscoveryMethod(v string) settingsv1.PeerDiscoveryMethod {
+	switch v {
+	case "dht_only":
+		return settingsv1.PeerDiscoveryMethod_PEER_DISCOVERY_DHT_ONLY
+	case "bootstrap_only":
+		return settingsv1.PeerDiscoveryMethod_PEER_DISCOVERY_BOOTSTRAP_ONLY
+	case "manual":
+		return settingsv1.PeerDiscoveryMethod_PEER_DISCOVERY_MANUAL
+	default:
+		return settingsv1.PeerDiscoveryMethod_PEER_DISCOVERY_DHT_AND_BOOTSTRAP
+	}
+}
+
+func unmapDiscoveryMethod(v settingsv1.PeerDiscoveryMethod) string {
+	switch v {
+	case settingsv1.PeerDiscoveryMethod_PEER_DISCOVERY_DHT_ONLY:
+		return "dht_only"
+	case settingsv1.PeerDiscoveryMethod_PEER_DISCOVERY_BOOTSTRAP_ONLY:
+		return "bootstrap_only"
+	case settingsv1.PeerDiscoveryMethod_PEER_DISCOVERY_MANUAL:
+		return "manual"
+	default:
+		return "dht_and_bootstrap"
+	}
+}
+
+func mapJoinPolicy(v string) settingsv1.ClusterJoinPolicy {
+	switch v {
+	case "approval":
+		return settingsv1.ClusterJoinPolicy_CLUSTER_JOIN_POLICY_APPROVAL
+	case "invite":
+		return settingsv1.ClusterJoinPolicy_CLUSTER_JOIN_POLICY_INVITE
+	default:
+		return settingsv1.ClusterJoinPolicy_CLUSTER_JOIN_POLICY_OPEN
+	}
+}
+
+func unmapJoinPolicy(v settingsv1.ClusterJoinPolicy) string {
+	switch v {
+	case settingsv1.ClusterJoinPolicy_CLUSTER_JOIN_POLICY_APPROVAL:
+		return "approval"
+	case settingsv1.ClusterJoinPolicy_CLUSTER_JOIN_POLICY_INVITE:
+		return "invite"
+	default:
+		return "open"
+	}
+}

--- a/apps/server/internal/connect/statuspage/statuspage.go
+++ b/apps/server/internal/connect/statuspage/statuspage.go
@@ -1,0 +1,184 @@
+package statuspage
+
+import (
+	"context"
+	"fmt"
+
+	"connectrpc.com/connect"
+	"go.uber.org/zap"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
+
+	statuspagev1 "github.com/Obiente/Uppe/apps/server/gen/statuspage/v1"
+	"github.com/Obiente/Uppe/apps/server/gen/statuspage/v1/statuspagev1connect"
+	"github.com/Obiente/Uppe/apps/server/internal/db"
+	"github.com/Obiente/Uppe/apps/server/internal/models"
+)
+
+type StatusPageService struct {
+	logger   *zap.Logger
+	database db.Database
+}
+
+var _ statuspagev1connect.StatusPageServiceHandler = (*StatusPageService)(nil)
+
+func NewStatusPageService(logger *zap.Logger, database db.Database) *StatusPageService {
+	return &StatusPageService{
+		logger:   logger,
+		database: database,
+	}
+}
+
+func (s *StatusPageService) CreateStatusPage(
+	ctx context.Context,
+	req *connect.Request[statuspagev1.CreateStatusPageRequest],
+) (*connect.Response[statuspagev1.StatusPage], error) {
+	if req.Msg.Title == "" || req.Msg.Slug == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("title and slug are required"))
+	}
+
+	page := &models.StatusPage{
+		Title:        req.Msg.Title,
+		Slug:         req.Msg.Slug,
+		Description:  req.Msg.Description,
+		MonitorIDs:   req.Msg.MonitorIds,
+		IsActive:     true,
+		PrimaryColor: req.Msg.PrimaryColor,
+	}
+	if req.Msg.LogoUrl != "" {
+		page.LogoURL = &req.Msg.LogoUrl
+	}
+
+	if err := s.database.CreateStatusPage(ctx, page); err != nil {
+		s.logger.Error("Failed to create status page", zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to create status page: %w", err))
+	}
+
+	stored, err := s.database.GetStatusPage(ctx, page.ID, false)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to reload status page: %w", err))
+	}
+	return connect.NewResponse(toProto(stored)), nil
+}
+
+func (s *StatusPageService) GetStatusPage(
+	ctx context.Context,
+	req *connect.Request[statuspagev1.GetStatusPageRequest],
+) (*connect.Response[statuspagev1.StatusPage], error) {
+	identifier := ""
+	bySlug := false
+	switch v := req.Msg.Identifier.(type) {
+	case *statuspagev1.GetStatusPageRequest_Id:
+		identifier = v.Id
+	case *statuspagev1.GetStatusPageRequest_Slug:
+		identifier = v.Slug
+		bySlug = true
+	}
+	if identifier == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("status page identifier is required"))
+	}
+
+	page, err := s.database.GetStatusPage(ctx, identifier, bySlug)
+	if err != nil {
+		s.logger.Error("Failed to load status page", zap.String("identifier", identifier), zap.Error(err))
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("failed to load status page: %w", err))
+	}
+
+	return connect.NewResponse(toProto(page)), nil
+}
+
+func (s *StatusPageService) ListStatusPages(
+	ctx context.Context,
+	req *connect.Request[statuspagev1.ListStatusPagesRequest],
+) (*connect.Response[statuspagev1.ListStatusPagesResponse], error) {
+	pages, total, err := s.database.ListStatusPages(ctx, int(req.Msg.Page), int(req.Msg.PageSize), req.Msg.ActiveOnly)
+	if err != nil {
+		s.logger.Error("Failed to list status pages", zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to list status pages: %w", err))
+	}
+
+	response := &statuspagev1.ListStatusPagesResponse{
+		StatusPages: make([]*statuspagev1.StatusPage, 0, len(pages)),
+		Total:       int32(total),
+	}
+	for _, page := range pages {
+		response.StatusPages = append(response.StatusPages, toProto(page))
+	}
+	return connect.NewResponse(response), nil
+}
+
+func (s *StatusPageService) UpdateStatusPage(
+	ctx context.Context,
+	req *connect.Request[statuspagev1.UpdateStatusPageRequest],
+) (*connect.Response[statuspagev1.StatusPage], error) {
+	update := &models.StatusPageUpdate{
+		Title:        req.Msg.Title,
+		Slug:         req.Msg.Slug,
+		Description:  req.Msg.Description,
+		IsActive:     req.Msg.IsActive,
+		LogoURL:      req.Msg.LogoUrl,
+		PrimaryColor: req.Msg.PrimaryColor,
+	}
+	if req.Msg.MonitorIds != nil {
+		update.MonitorIDs = req.Msg.MonitorIds
+		update.ReplaceMonitorIDs = true
+	}
+
+	if err := s.database.UpdateStatusPage(ctx, req.Msg.Id, update); err != nil {
+		s.logger.Error("Failed to update status page", zap.String("id", req.Msg.Id), zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to update status page: %w", err))
+	}
+
+	page, err := s.database.GetStatusPage(ctx, req.Msg.Id, false)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to reload status page: %w", err))
+	}
+	return connect.NewResponse(toProto(page)), nil
+}
+
+func (s *StatusPageService) DeleteStatusPage(
+	ctx context.Context,
+	req *connect.Request[statuspagev1.DeleteStatusPageRequest],
+) (*connect.Response[emptypb.Empty], error) {
+	if err := s.database.DeleteStatusPage(ctx, req.Msg.Id); err != nil {
+		s.logger.Error("Failed to delete status page", zap.String("id", req.Msg.Id), zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to delete status page: %w", err))
+	}
+	return connect.NewResponse(&emptypb.Empty{}), nil
+}
+
+func (s *StatusPageService) RecordVisit(
+	ctx context.Context,
+	req *connect.Request[statuspagev1.RecordVisitRequest],
+) (*connect.Response[emptypb.Empty], error) {
+	if err := s.database.RecordStatusPageVisit(ctx, req.Msg.StatusPageId); err != nil {
+		s.logger.Error("Failed to record status page visit", zap.String("id", req.Msg.StatusPageId), zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to record status page visit: %w", err))
+	}
+	return connect.NewResponse(&emptypb.Empty{}), nil
+}
+
+func toProto(page *models.StatusPage) *statuspagev1.StatusPage {
+	proto := &statuspagev1.StatusPage{
+		Id:           page.ID,
+		Title:        page.Title,
+		Slug:         page.Slug,
+		MonitorIds:   page.MonitorIDs,
+		IsActive:     page.IsActive,
+		PrimaryColor: page.PrimaryColor,
+		Description:  page.Description,
+		Uptime:       page.Uptime,
+		Visits:       page.Visits,
+		CreatedAt:    page.CreatedAt.Unix(),
+		UpdatedAt:    page.UpdatedAt.Unix(),
+	}
+	if page.CustomDomain != nil {
+		proto.CustomDomain = *page.CustomDomain
+	}
+	if page.LogoURL != nil {
+		proto.LogoUrl = *page.LogoURL
+	}
+	if page.LastIncident != nil {
+		proto.LastIncident = page.LastIncident.Unix()
+	}
+	return proto
+}

--- a/apps/server/internal/db/libsql/libsql.go
+++ b/apps/server/internal/db/libsql/libsql.go
@@ -1,0 +1,1556 @@
+package libsql
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	commonv1 "github.com/Obiente/Uppe/apps/server/gen/common/v1"
+	monitorv1 "github.com/Obiente/Uppe/apps/server/gen/monitor/v1"
+	resultv1 "github.com/Obiente/Uppe/apps/server/gen/result/v1"
+	"github.com/Obiente/Uppe/apps/server/internal/db/types"
+	"github.com/Obiente/Uppe/apps/server/internal/models"
+	_ "modernc.org/sqlite"
+)
+
+// Minimum required schema version (must match Rust service migrations)
+// v4 added visibility, owner_peer_id, public_domain, public_display_name to monitors.
+const MinRequiredSchemaVersion = 4
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// generateUUID generates a simple UUID v4
+func generateUUID() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	b[6] = (b[6] & 0x0f) | 0x40 // Version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // Variant
+	return hex.EncodeToString(b[:4]) + "-" +
+		hex.EncodeToString(b[4:6]) + "-" +
+		hex.EncodeToString(b[6:8]) + "-" +
+		hex.EncodeToString(b[8:10]) + "-" +
+		hex.EncodeToString(b[10:])
+}
+
+// boolToInt converts bool to int for SQLite
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// Helper function to convert ResultStatus enum to string
+func resultStatusToString(status resultv1.ResultStatus) string {
+	switch status {
+	case resultv1.ResultStatus_RESULT_STATUS_UP:
+		return "Up"
+	case resultv1.ResultStatus_RESULT_STATUS_DOWN:
+		return "Down"
+	case resultv1.ResultStatus_RESULT_STATUS_TIMEOUT:
+		return "Timeout"
+	case resultv1.ResultStatus_RESULT_STATUS_ERROR:
+		return "Error"
+	default:
+		return "Error"
+	}
+}
+
+// LibSQLDatabase implements the Database interface using LibSQL (SQLite-compatible)
+//
+// IMPORTANT: This API server does NOT manage database migrations.
+// The Rust service (apps/service) is the single source of truth for schema.
+// This API only reads data from the shared database.
+type LibSQLDatabase struct {
+	db *sql.DB
+}
+
+// NewWithRetry creates a new LibSQL database connection, retrying until schema is ready
+// This allows the Go API to start concurrently with the Rust service
+func NewWithRetry(databaseURL string, maxRetries int, retryInterval time.Duration) (*LibSQLDatabase, error) {
+	var lastErr error
+
+	for i := 0; i < maxRetries; i++ {
+		db, err := New(databaseURL)
+		if err == nil {
+			return db, nil
+		}
+
+		lastErr = err
+
+		// Log retry attempt (only after first failure)
+		if i == 0 {
+			fmt.Printf("Waiting for database schema (Rust service must initialize first)...\n")
+		}
+
+		time.Sleep(retryInterval)
+	}
+
+	return nil, fmt.Errorf("database not ready after %d attempts: %w", maxRetries, lastErr)
+}
+
+// New creates a new LibSQL database connection
+// NOTE: Does NOT run migrations - schema is managed by Rust service
+func New(databaseURL string) (*LibSQLDatabase, error) {
+	// For local SQLite files, use sqlite3 driver
+	// Remove file:// prefix if present for sqlite3 driver
+	dbPath := databaseURL
+	if len(dbPath) > 7 && dbPath[:7] == "file://" {
+		dbPath = dbPath[7:]
+	}
+
+	sqlDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
+	}
+
+	// Test connection
+	if err := sqlDB.Ping(); err != nil {
+		return nil, fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	db := &LibSQLDatabase{
+		db: sqlDB,
+	}
+
+	// Verify schema compatibility (do NOT run migrations)
+	if err := db.verifySchema(context.Background()); err != nil {
+		return nil, fmt.Errorf("schema verification failed: %w", err)
+	}
+
+	return db, nil
+}
+
+// verifySchema checks that the database schema is compatible
+// Returns error if schema is missing or incompatible
+func (d *LibSQLDatabase) verifySchema(ctx context.Context) error {
+	// Check if schema_migrations table exists
+	var count int
+	err := d.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='schema_migrations'",
+	).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("failed to check schema_migrations table: %w", err)
+	}
+
+	if count == 0 {
+		return fmt.Errorf("database not initialized - run Rust service first to create schema")
+	}
+
+	// Check schema version
+	var version int
+	err = d.db.QueryRowContext(ctx, "SELECT MAX(version) FROM schema_migrations").Scan(&version)
+	if err != nil {
+		return fmt.Errorf("failed to get schema version: %w", err)
+	}
+
+	if version < MinRequiredSchemaVersion {
+		return fmt.Errorf("schema version %d is too old, need at least version %d - run Rust service to update",
+			version, MinRequiredSchemaVersion)
+	}
+
+	// Verify required tables exist
+	requiredTables := []string{"monitors", "monitor_results", "peer_results"}
+	for _, table := range requiredTables {
+		var tableCount int
+		err := d.db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?",
+			table,
+		).Scan(&tableCount)
+		if err != nil || tableCount == 0 {
+			return fmt.Errorf("required table '%s' not found - run Rust service first", table)
+		}
+	}
+
+	return nil
+}
+
+// Ping checks database connectivity
+func (d *LibSQLDatabase) Ping(ctx context.Context) error {
+	return d.db.PingContext(ctx)
+}
+
+// Close closes the database connection
+func (d *LibSQLDatabase) Close() error {
+	return d.db.Close()
+}
+
+// CreateMonitor creates a new monitor using raw SQL to match Rust schema
+func (d *LibSQLDatabase) CreateMonitor(ctx context.Context, monitor *models.Monitor) error {
+	// Generate UUID if not set
+	if monitor.ID == "" {
+		monitor.ID = generateUUID()
+	}
+
+	// Serialize JSON fields
+	expectedCodesJSON, _ := json.Marshal(monitor.ExpectedStatusCodes)
+	if len(monitor.ExpectedStatusCodes) == 0 {
+		expectedCodesJSON = []byte(`["200"]`)
+	}
+	headersJSON, _ := json.Marshal(monitor.Headers)
+	if monitor.Headers == nil {
+		headersJSON = []byte(`{}`)
+	}
+
+	// Convert type to Rust format
+	checkType := "Http"
+	switch monitor.Type {
+	case monitorv1.MonitorType_MONITOR_TYPE_HTTP:
+		checkType = "Http"
+	case monitorv1.MonitorType_MONITOR_TYPE_TCP:
+		checkType = "Tcp"
+	case monitorv1.MonitorType_MONITOR_TYPE_ICMP:
+		checkType = "Icmp"
+	}
+
+	now := time.Now().Unix()
+
+	// Determine visibility string; default to Private
+	visibility := string(monitor.Visibility)
+	if visibility == "" {
+		visibility = "Private"
+	}
+
+	_, err := d.db.ExecContext(ctx, `
+		INSERT INTO monitors (uuid, name, target, check_type, interval_seconds, timeout_seconds,
+			expected_status_codes, headers, body, enabled, user_id, created_at, updated_at,
+			visibility, owner_peer_id, public_domain, public_display_name)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		monitor.ID,
+		monitor.Name,
+		monitor.URL,
+		checkType,
+		monitor.IntervalSeconds,
+		monitor.TimeoutSeconds,
+		string(expectedCodesJSON),
+		string(headersJSON),
+		monitor.Body,
+		boolToInt(monitor.Enabled),
+		monitor.UserID,
+		now,
+		now,
+		visibility,
+		monitor.OwnerPeerID,
+		monitor.PublicDomain,
+		monitor.PublicDisplayName,
+	)
+
+	return err
+}
+
+// GetMonitor retrieves a monitor by UUID
+func (d *LibSQLDatabase) GetMonitor(ctx context.Context, id string) (*models.Monitor, error) {
+	query := `
+		SELECT uuid, target, name, check_type, interval_seconds, timeout_seconds,
+			COALESCE(expected_status_codes, '[]'), COALESCE(headers, '{}'),
+			COALESCE(body, ''), enabled, user_id, created_at, updated_at,
+			COALESCE(visibility, 'Private'), owner_peer_id, public_domain, public_display_name
+		FROM monitors WHERE uuid = ?
+	`
+
+	var monitor models.Monitor
+	var expectedCodesJSON, headersJSON, typeStr, visibilityStr string
+	var enabled int
+	var userID, ownerPeerID, publicDomain, publicDisplayName sql.NullString
+	var createdAt, updatedAt int64
+
+	err := d.db.QueryRowContext(ctx, query, id).Scan(
+		&monitor.ID,
+		&monitor.URL,
+		&monitor.Name,
+		&typeStr,
+		&monitor.IntervalSeconds,
+		&monitor.TimeoutSeconds,
+		&expectedCodesJSON,
+		&headersJSON,
+		&monitor.Body,
+		&enabled,
+		&userID,
+		&createdAt,
+		&updatedAt,
+		&visibilityStr,
+		&ownerPeerID,
+		&publicDomain,
+		&publicDisplayName,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("monitor not found")
+		}
+		return nil, fmt.Errorf("failed to get monitor: %w", err)
+	}
+
+	// Parse type
+	switch typeStr {
+	case "http", "Http", "HTTP", "https", "Https", "HTTPS":
+		monitor.Type = monitorv1.MonitorType_MONITOR_TYPE_HTTP
+	case "tcp", "Tcp", "TCP":
+		monitor.Type = monitorv1.MonitorType_MONITOR_TYPE_TCP
+	case "icmp", "Icmp", "ICMP":
+		monitor.Type = monitorv1.MonitorType_MONITOR_TYPE_ICMP
+	default:
+		monitor.Type = monitorv1.MonitorType_MONITOR_TYPE_HTTP
+	}
+
+	monitor.Visibility = models.MonitorVisibility(visibilityStr)
+	if monitor.Visibility == "" {
+		monitor.Visibility = models.MonitorVisibilityPrivate
+	}
+	if ownerPeerID.Valid {
+		monitor.OwnerPeerID = &ownerPeerID.String
+	}
+	if publicDomain.Valid {
+		monitor.PublicDomain = &publicDomain.String
+	}
+	if publicDisplayName.Valid {
+		monitor.PublicDisplayName = &publicDisplayName.String
+	}
+
+	monitor.Enabled = enabled == 1
+	if userID.Valid {
+		monitor.UserID = &userID.String
+	}
+
+	monitor.CreatedAt = time.Unix(createdAt, 0)
+	monitor.UpdatedAt = time.Unix(updatedAt, 0)
+
+	json.Unmarshal([]byte(expectedCodesJSON), &monitor.ExpectedStatusCodes)
+	json.Unmarshal([]byte(headersJSON), &monitor.Headers)
+
+	return &monitor, nil
+}
+
+// ListMonitors lists monitors with filters
+func (d *LibSQLDatabase) ListMonitors(ctx context.Context, filters *types.MonitorFilters) ([]*models.Monitor, int, error) {
+	// Build WHERE clause
+	where := []string{}
+	args := []interface{}{}
+
+	if filters.UserID != nil {
+		where = append(where, "user_id = ?")
+		args = append(args, *filters.UserID)
+	}
+	if filters.Enabled != nil {
+		where = append(where, "enabled = ?")
+		enabledVal := 0
+		if *filters.Enabled {
+			enabledVal = 1
+		}
+		args = append(args, enabledVal)
+	}
+	if filters.Visibility != nil && *filters.Visibility != "" {
+		where = append(where, "visibility = ?")
+		args = append(args, *filters.Visibility)
+	}
+
+	whereClause := ""
+	if len(where) > 0 {
+		whereClause = "WHERE " + where[0]
+		for i := 1; i < len(where); i++ {
+			whereClause += " AND " + where[i]
+		}
+	}
+
+	// Get total count
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM monitors %s", whereClause)
+	var total int
+	err := d.db.QueryRowContext(ctx, countQuery, args...).Scan(&total)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to count monitors: %w", err)
+	}
+
+	// Get monitors - include visibility columns (schema v4+)
+	query := fmt.Sprintf(`
+		SELECT uuid, target, name, check_type, interval_seconds, timeout_seconds,
+			COALESCE(expected_status_codes, '[]'), COALESCE(headers, '{}'),
+			COALESCE(body, ''), enabled, user_id, created_at, updated_at,
+			COALESCE(visibility, 'Private'), owner_peer_id, public_domain, public_display_name
+		FROM monitors %s
+		ORDER BY created_at DESC
+		LIMIT ? OFFSET ?
+	`, whereClause)
+
+	limit := filters.PageSize
+	if limit == 0 {
+		limit = 50 // default
+	}
+	offset := (filters.Page - 1) * limit
+	if offset < 0 {
+		offset = 0
+	}
+
+	args = append(args, limit, offset)
+	rows, err := d.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to query monitors: %w", err)
+	}
+	defer rows.Close()
+
+	monitors := []*models.Monitor{}
+	for rows.Next() {
+		var monitor models.Monitor
+		var expectedCodesJSON, headersJSON, typeStr, visibilityStr string
+		var enabled int
+		var userID, ownerPeerID, publicDomain, publicDisplayName sql.NullString
+		var createdAt, updatedAt int64
+
+		err := rows.Scan(
+			&monitor.ID,
+			&monitor.URL,
+			&monitor.Name,
+			&typeStr,
+			&monitor.IntervalSeconds,
+			&monitor.TimeoutSeconds,
+			&expectedCodesJSON,
+			&headersJSON,
+			&monitor.Body,
+			&enabled,
+			&userID,
+			&createdAt,
+			&updatedAt,
+			&visibilityStr,
+			&ownerPeerID,
+			&publicDomain,
+			&publicDisplayName,
+		)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to scan monitor: %w", err)
+		}
+
+		// Parse check_type — Rust stores as Http, Tcp, Icmp
+		switch typeStr {
+		case "http", "Http", "HTTP", "https", "Https", "HTTPS":
+			monitor.Type = monitorv1.MonitorType_MONITOR_TYPE_HTTP
+		case "tcp", "Tcp", "TCP":
+			monitor.Type = monitorv1.MonitorType_MONITOR_TYPE_TCP
+		case "icmp", "Icmp", "ICMP":
+			monitor.Type = monitorv1.MonitorType_MONITOR_TYPE_ICMP
+		default:
+			monitor.Type = monitorv1.MonitorType_MONITOR_TYPE_HTTP
+		}
+
+		monitor.Visibility = models.MonitorVisibility(visibilityStr)
+		if monitor.Visibility == "" {
+			monitor.Visibility = models.MonitorVisibilityPrivate
+		}
+		if ownerPeerID.Valid {
+			monitor.OwnerPeerID = &ownerPeerID.String
+		}
+		if publicDomain.Valid {
+			monitor.PublicDomain = &publicDomain.String
+		}
+		if publicDisplayName.Valid {
+			monitor.PublicDisplayName = &publicDisplayName.String
+		}
+
+		monitor.Enabled = enabled == 1
+		if userID.Valid {
+			monitor.UserID = &userID.String
+		}
+
+		monitor.CreatedAt = time.Unix(createdAt, 0)
+		monitor.UpdatedAt = time.Unix(updatedAt, 0)
+
+		json.Unmarshal([]byte(expectedCodesJSON), &monitor.ExpectedStatusCodes)
+		json.Unmarshal([]byte(headersJSON), &monitor.Headers)
+
+		monitors = append(monitors, &monitor)
+	}
+
+	return monitors, total, nil
+}
+
+// UpdateMonitor updates a monitor by UUID
+func (d *LibSQLDatabase) UpdateMonitor(ctx context.Context, id string, updates *models.MonitorUpdate) error {
+	// Build SET clause dynamically
+	setClauses := []string{}
+	args := []interface{}{}
+
+	if updates.Name != nil {
+		setClauses = append(setClauses, "name = ?")
+		args = append(args, *updates.Name)
+	}
+	if updates.IntervalSeconds != nil {
+		setClauses = append(setClauses, "interval_seconds = ?")
+		args = append(args, *updates.IntervalSeconds)
+	}
+	if updates.TimeoutSeconds != nil {
+		setClauses = append(setClauses, "timeout_seconds = ?")
+		args = append(args, *updates.TimeoutSeconds)
+	}
+	if updates.Enabled != nil {
+		setClauses = append(setClauses, "enabled = ?")
+		args = append(args, boolToInt(*updates.Enabled))
+	}
+	if updates.Body != nil {
+		setClauses = append(setClauses, "body = ?")
+		args = append(args, *updates.Body)
+	}
+	if updates.Headers != nil {
+		headersJSON, err := json.Marshal(updates.Headers)
+		if err != nil {
+			return fmt.Errorf("failed to marshal headers: %w", err)
+		}
+		setClauses = append(setClauses, "headers = ?")
+		args = append(args, string(headersJSON))
+	}
+	if updates.PublicDomain != nil {
+		setClauses = append(setClauses, "public_domain = ?")
+		args = append(args, *updates.PublicDomain)
+	}
+	if updates.PublicDisplayName != nil {
+		setClauses = append(setClauses, "public_display_name = ?")
+		args = append(args, *updates.PublicDisplayName)
+	}
+
+	if len(setClauses) == 0 {
+		return fmt.Errorf("no fields to update")
+	}
+
+	// Always update updated_at
+	setClauses = append(setClauses, "updated_at = ?")
+	args = append(args, time.Now().Unix())
+
+	// Add the WHERE clause parameter
+	args = append(args, id)
+
+	query := fmt.Sprintf("UPDATE monitors SET %s WHERE uuid = ?",
+		joinStrings(setClauses, ", "))
+
+	_, err := d.db.ExecContext(ctx, query, args...)
+	return err
+}
+
+// DeleteMonitor deletes a monitor by UUID
+func (d *LibSQLDatabase) DeleteMonitor(ctx context.Context, id string) error {
+	_, err := d.db.ExecContext(ctx, "DELETE FROM monitors WHERE uuid = ?", id)
+	return err
+}
+
+// joinStrings joins strings with separator (helper function)
+func joinStrings(strs []string, sep string) string {
+	if len(strs) == 0 {
+		return ""
+	}
+	result := strs[0]
+	for i := 1; i < len(strs); i++ {
+		result += sep + strs[i]
+	}
+	return result
+}
+
+// SaveResult saves a monitoring result
+func (d *LibSQLDatabase) SaveResult(ctx context.Context, result *models.MonitoringResult) error {
+	query := `
+		INSERT INTO monitoring_results (
+			id, monitor_id, timestamp, status, latency_ms, status_code,
+			monitor_node_id, signature, error_message, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`
+
+	var statusCode interface{}
+	if result.StatusCode != nil {
+		statusCode = *result.StatusCode
+	}
+
+	var errorMsg interface{}
+	if result.ErrorMessage != nil {
+		errorMsg = *result.ErrorMessage
+	}
+
+	_, err := d.db.ExecContext(ctx, query,
+		result.ID,
+		result.MonitorID,
+		result.Timestamp.Unix(),
+		resultStatusToString(result.Status),
+		result.LatencyMs,
+		statusCode,
+		result.MonitorNodeID,
+		result.Signature,
+		errorMsg,
+		result.CreatedAt.Unix(),
+	)
+
+	return err
+}
+
+// GetResults retrieves monitoring results
+func (d *LibSQLDatabase) GetResults(ctx context.Context, query *types.ResultQuery) ([]*models.MonitoringResult, int, error) {
+	// Get total count
+	countQuery := `
+		SELECT COUNT(*) FROM monitor_results
+		WHERE monitor_uuid = ?
+		AND timestamp >= ? AND timestamp <= ?
+	`
+	var total int
+	err := d.db.QueryRowContext(ctx, countQuery,
+		query.MonitorID,
+		query.StartTime.Unix(),
+		query.EndTime.Unix(),
+	).Scan(&total)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to count results: %w", err)
+	}
+
+	// Get results
+	resultsQuery := `
+		SELECT id, monitor_uuid, timestamp, status, latency_ms, status_code,
+			peer_id, signature, error_message, created_at,
+			city, country, region
+		FROM monitor_results
+		WHERE monitor_uuid = ?
+		AND timestamp >= ? AND timestamp <= ?
+		ORDER BY timestamp DESC
+		LIMIT ? OFFSET ?
+	`
+
+	limit := query.Limit
+	if limit == 0 {
+		limit = 100
+	}
+
+	rows, err := d.db.QueryContext(ctx, resultsQuery,
+		query.MonitorID,
+		query.StartTime.Unix(),
+		query.EndTime.Unix(),
+		limit,
+		query.Offset,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to query results: %w", err)
+	}
+	defer rows.Close()
+
+	results := []*models.MonitoringResult{}
+	for rows.Next() {
+		var result models.MonitoringResult
+		var rowID int64
+		var statusStr string
+		var latencyMs sql.NullInt64
+		var statusCode sql.NullInt32
+		var errorMsg sql.NullString
+		var peerID sql.NullString
+		var signature []byte
+		var timestamp, createdAt int64
+		var city, country, region sql.NullString
+
+		err := rows.Scan(
+			&rowID,
+			&result.MonitorID,
+			&timestamp,
+			&statusStr,
+			&latencyMs,
+			&statusCode,
+			&peerID,
+			&signature,
+			&errorMsg,
+			&createdAt,
+			&city,
+			&country,
+			&region,
+		)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to scan result: %w", err)
+		}
+
+		result.ID = fmt.Sprintf("%d", rowID)
+		result.Timestamp = time.Unix(timestamp, 0)
+		result.CreatedAt = time.Unix(createdAt, 0)
+
+		if latencyMs.Valid {
+			result.LatencyMs = latencyMs.Int64
+		}
+		if peerID.Valid {
+			result.MonitorNodeID = peerID.String
+		}
+
+		// Parse status - Rust stores as Up, Down, Timeout, Error
+		switch statusStr {
+		case "Up", "UP", "up":
+			result.Status = resultv1.ResultStatus_RESULT_STATUS_UP
+		case "Down", "DOWN", "down":
+			result.Status = resultv1.ResultStatus_RESULT_STATUS_DOWN
+		case "Timeout", "TIMEOUT", "timeout":
+			result.Status = resultv1.ResultStatus_RESULT_STATUS_TIMEOUT
+		case "Error", "ERROR", "error":
+			result.Status = resultv1.ResultStatus_RESULT_STATUS_ERROR
+		case "Degraded", "degraded":
+			result.Status = resultv1.ResultStatus_RESULT_STATUS_DEGRADED
+		default:
+			result.Status = resultv1.ResultStatus_RESULT_STATUS_ERROR
+		}
+
+		if statusCode.Valid {
+			result.StatusCode = &statusCode.Int32
+		}
+		if errorMsg.Valid {
+			result.ErrorMessage = &errorMsg.String
+		}
+		if len(signature) > 0 {
+			result.Signature = signature
+		}
+		if city.Valid || country.Valid || region.Valid {
+			result.Location = &commonv1.Location{
+				City:    city.String,
+				Country: country.String,
+				Region:  region.String,
+			}
+		}
+
+		results = append(results, &result)
+	}
+
+	return results, total, nil
+}
+
+// GetMonitorStats retrieves computed statistics for a monitor over a time period
+func (d *LibSQLDatabase) GetMonitorStats(ctx context.Context, monitorID string, startTime, endTime time.Time) (*models.MonitorStats, error) {
+	query := `
+		SELECT
+			COUNT(*) as total_checks,
+			SUM(CASE WHEN status IN ('Up', 'UP') THEN 1 ELSE 0 END) as successful_checks,
+			COALESCE(AVG(CAST(latency_ms AS REAL)), 0) as avg_latency,
+			COALESCE(MIN(latency_ms), 0) as min_latency,
+			COALESCE(MAX(latency_ms), 0) as max_latency
+		FROM monitor_results
+		WHERE monitor_uuid = ? AND timestamp >= ? AND timestamp <= ?
+	`
+
+	stats := &models.MonitorStats{MonitorID: monitorID}
+	err := d.db.QueryRowContext(ctx, query,
+		monitorID,
+		startTime.Unix(),
+		endTime.Unix(),
+	).Scan(
+		&stats.TotalChecks,
+		&stats.SuccessfulChecks,
+		&stats.AverageLatencyMs,
+		&stats.MinLatencyMs,
+		&stats.MaxLatencyMs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query monitor stats: %w", err)
+	}
+
+	stats.FailedChecks = stats.TotalChecks - stats.SuccessfulChecks
+	if stats.TotalChecks > 0 {
+		stats.UptimePercentage = float64(stats.SuccessfulChecks) / float64(stats.TotalChecks) * 100
+	}
+
+	return stats, nil
+}
+
+// GetAggregatedStats gets aggregated statistics bucketed by calendar period
+func (d *LibSQLDatabase) GetAggregatedStats(ctx context.Context, monitorID string, startTime, endTime time.Time, period types.AggregationPeriod) ([]*models.TimeSeriesDataPoint, error) {
+	// Group by calendar day using SQLite's strftime
+	var bucketFmt string
+	switch period {
+	case types.AggregationPeriodHour:
+		bucketFmt = "%Y-%m-%dT%H:00:00"
+	case types.AggregationPeriodWeek:
+		bucketFmt = "%Y-W%W"
+	case types.AggregationPeriodMonth:
+		bucketFmt = "%Y-%m-01"
+	default: // Day
+		bucketFmt = "%Y-%m-%d"
+	}
+
+	query := fmt.Sprintf(`
+		SELECT
+			MIN(timestamp) as bucket_ts,
+			COUNT(*) as total_checks,
+			SUM(CASE WHEN status IN ('Up', 'UP') THEN 1 ELSE 0 END) as successful_checks,
+			COALESCE(AVG(CAST(latency_ms AS REAL)), 0) as avg_latency
+		FROM monitor_results
+		WHERE monitor_uuid = ? AND timestamp >= ? AND timestamp <= ?
+		GROUP BY strftime('%s', datetime(timestamp, 'unixepoch'))
+		ORDER BY bucket_ts ASC
+	`, bucketFmt)
+
+	rows, err := d.db.QueryContext(ctx, query,
+		monitorID,
+		startTime.Unix(),
+		endTime.Unix(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query aggregated stats: %w", err)
+	}
+	defer rows.Close()
+
+	points := []*models.TimeSeriesDataPoint{}
+	for rows.Next() {
+		var point models.TimeSeriesDataPoint
+		var timestamp int64
+		var totalChecks, successfulChecks int64
+		var avgLatency float64
+
+		err := rows.Scan(&timestamp, &totalChecks, &successfulChecks, &avgLatency)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan data point: %w", err)
+		}
+
+		point.Timestamp = time.Unix(timestamp, 0)
+		point.TotalChecks = totalChecks
+		point.SuccessfulChecks = successfulChecks
+		if totalChecks > 0 {
+			point.UptimePercentage = float64(successfulChecks) / float64(totalChecks) * 100
+		}
+		point.AverageLatencyMs = avgLatency
+
+		points = append(points, &point)
+	}
+
+	return points, nil
+}
+
+// GetGlobalPingSamples retrieves raw monitoring samples for a monitor across nodes within a time range
+func (d *LibSQLDatabase) GetGlobalPingSamples(ctx context.Context, monitorID string, startTime, endTime time.Time) ([]*models.MonitoringResult, error) {
+	query := `
+		SELECT id, monitor_uuid, timestamp, status, latency_ms, status_code,
+			peer_id, signature, error_message, created_at
+		FROM monitor_results
+		WHERE monitor_uuid = ? AND timestamp >= ? AND timestamp <= ?
+		ORDER BY timestamp DESC
+	`
+
+	rows, err := d.db.QueryContext(ctx, query,
+		monitorID,
+		startTime.Unix(),
+		endTime.Unix(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query global ping samples: %w", err)
+	}
+	defer rows.Close()
+
+	samples := []*models.MonitoringResult{}
+	for rows.Next() {
+		var result models.MonitoringResult
+		var rowID int64
+		var statusStr string
+		var latencyMs sql.NullInt64
+		var statusCode sql.NullInt32
+		var errorMsg sql.NullString
+		var peerID sql.NullString
+		var signature []byte
+		var timestamp, createdAt int64
+
+		err := rows.Scan(
+			&rowID,
+			&result.MonitorID,
+			&timestamp,
+			&statusStr,
+			&latencyMs,
+			&statusCode,
+			&peerID,
+			&signature,
+			&errorMsg,
+			&createdAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan global ping sample: %w", err)
+		}
+
+		result.ID = fmt.Sprintf("%d", rowID)
+		result.Timestamp = time.Unix(timestamp, 0)
+		result.CreatedAt = time.Unix(createdAt, 0)
+
+		if latencyMs.Valid {
+			result.LatencyMs = latencyMs.Int64
+		}
+		if peerID.Valid {
+			result.MonitorNodeID = peerID.String
+		}
+		if len(signature) > 0 {
+			result.Signature = signature
+		}
+
+		// Parse status - Rust stores as Up, Down, Timeout, Error
+		switch statusStr {
+		case "Up", "UP", "up":
+			result.Status = resultv1.ResultStatus_RESULT_STATUS_UP
+		case "Down", "DOWN", "down":
+			result.Status = resultv1.ResultStatus_RESULT_STATUS_DOWN
+		case "Timeout", "TIMEOUT", "timeout":
+			result.Status = resultv1.ResultStatus_RESULT_STATUS_TIMEOUT
+		case "Error", "ERROR", "error":
+			result.Status = resultv1.ResultStatus_RESULT_STATUS_ERROR
+		case "Degraded", "degraded":
+			result.Status = resultv1.ResultStatus_RESULT_STATUS_DEGRADED
+		default:
+			result.Status = resultv1.ResultStatus_RESULT_STATUS_ERROR
+		}
+
+		if statusCode.Valid {
+			result.StatusCode = &statusCode.Int32
+		}
+		if errorMsg.Valid {
+			result.ErrorMessage = &errorMsg.String
+		}
+
+		samples = append(samples, &result)
+	}
+
+	return samples, nil
+}
+
+func (d *LibSQLDatabase) GetSetting(ctx context.Context, key string) (string, bool, error) {
+	var value string
+	err := d.db.QueryRowContext(ctx, "SELECT value FROM settings WHERE key = ?", key).Scan(&value)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("failed to get setting %s: %w", key, err)
+	}
+	return value, true, nil
+}
+
+func (d *LibSQLDatabase) SetSetting(ctx context.Context, key string, value string) error {
+	_, err := d.db.ExecContext(ctx, `
+		INSERT INTO settings (key, value, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+	`, key, value, time.Now().Unix())
+	if err != nil {
+		return fmt.Errorf("failed to set setting %s: %w", key, err)
+	}
+	return nil
+}
+
+func (d *LibSQLDatabase) GetNodeIdentity(ctx context.Context) (*models.NodeIdentity, error) {
+	nodeName := "Uppe. Node"
+	if value, ok, err := d.GetSetting(ctx, "display_name"); err != nil {
+		return nil, err
+	} else if ok && value != "" {
+		nodeName = value
+	}
+
+	var nodeID string
+	_ = d.db.QueryRowContext(ctx, `
+		SELECT peer_id FROM monitor_results
+		WHERE peer_id IS NOT NULL AND peer_id != ''
+		ORDER BY created_at DESC
+		LIMIT 1
+	`).Scan(&nodeID)
+
+	var joinedAt int64
+	_ = d.db.QueryRowContext(ctx, "SELECT COALESCE(MIN(applied_at), 0) FROM schema_migrations").Scan(&joinedAt)
+
+	var totalChecksPerformed int64
+	_ = d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM monitor_results").Scan(&totalChecksPerformed)
+
+	var totalChecksReceived int64
+	_ = d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM peer_results").Scan(&totalChecksReceived)
+
+	return &models.NodeIdentity{
+		NodeID:               nodeID,
+		NodeName:             nodeName,
+		JoinedNetworkAt:      time.Unix(joinedAt, 0),
+		ContributionScore:    1.0,
+		TotalChecksPerformed: totalChecksPerformed,
+		TotalChecksReceived:  totalChecksReceived,
+	}, nil
+}
+
+func (d *LibSQLDatabase) GetNetworkStats(ctx context.Context) (*models.NetworkStats, error) {
+	nodeIdentity, err := d.GetNodeIdentity(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	stats := &models.NetworkStats{
+		MyNodeID:          nodeIdentity.NodeID,
+		ContributionScore: nodeIdentity.ContributionScore,
+	}
+
+	var totalPeers, onlinePeers, checksPerformed, checksReceived, bandwidthUsed sql.NullInt64
+	err = d.db.QueryRowContext(ctx, `
+		SELECT total_peers, online_peers, checks_performed, checks_received, bandwidth_used_mb
+		FROM network_stats
+		ORDER BY timestamp DESC
+		LIMIT 1
+	`).Scan(&totalPeers, &onlinePeers, &checksPerformed, &checksReceived, &bandwidthUsed)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("failed to load network stats: %w", err)
+	}
+
+	if err == sql.ErrNoRows {
+		if queryErr := d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM peers").Scan(&stats.TotalPeers); queryErr != nil {
+			return nil, fmt.Errorf("failed to count peers: %w", queryErr)
+		}
+		if queryErr := d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM peers WHERE status = 'online'").Scan(&stats.OnlinePeers); queryErr != nil {
+			return nil, fmt.Errorf("failed to count online peers: %w", queryErr)
+		}
+	} else {
+		stats.TotalPeers = totalPeers.Int64
+		stats.OnlinePeers = onlinePeers.Int64
+		stats.MonitoringForOthers = checksPerformed.Int64
+		stats.ReceivingFromOthers = checksReceived.Int64
+		stats.BandwidthUsedMb = bandwidthUsed.Int64
+		stats.ChecksPerHour = checksPerformed.Int64 + checksReceived.Int64
+	}
+
+	if stats.TotalPeers > 0 {
+		stats.CoveragePercentage = (float64(stats.OnlinePeers) / float64(stats.TotalPeers)) * 100
+	}
+
+	if stats.ReceivingFromOthers > 0 {
+		stats.ShareRatio = float64(stats.MonitoringForOthers) / float64(stats.ReceivingFromOthers)
+	} else {
+		stats.ShareRatio = 1.0
+	}
+
+	startOfDay := time.Now().UTC().Truncate(24 * time.Hour).Unix()
+	_ = d.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM monitor_results WHERE timestamp >= ?",
+		startOfDay,
+	).Scan(&stats.ChecksPerformedToday)
+	_ = d.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM peer_results WHERE timestamp >= ?",
+		startOfDay,
+	).Scan(&stats.ChecksReceivedToday)
+
+	if value, ok, getErr := d.GetSetting(ctx, "max_bandwidth_mb_per_day"); getErr != nil {
+		return nil, getErr
+	} else if ok && value != "" {
+		var parsed int64
+		if _, scanErr := fmt.Sscan(value, &parsed); scanErr == nil {
+			stats.BandwidthLimitMb = parsed
+		}
+	}
+	if stats.BandwidthLimitMb == 0 {
+		stats.BandwidthLimitMb = 100
+	}
+
+	return stats, nil
+}
+
+func (d *LibSQLDatabase) ListPeers(ctx context.Context, query *types.PeerQuery) ([]*models.NetworkPeer, int, error) {
+	where := []string{}
+	args := []interface{}{}
+
+	if query != nil && query.FilterStatus != "" {
+		where = append(where, "status = ?")
+		args = append(args, query.FilterStatus)
+	}
+
+	whereClause := ""
+	if len(where) > 0 {
+		whereClause = "WHERE " + joinStrings(where, " AND ")
+	}
+
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM peers %s", whereClause)
+	var total int
+	if err := d.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("failed to count peers: %w", err)
+	}
+
+	orderBy := "last_seen DESC"
+	if query != nil {
+		switch query.SortBy {
+		case "contribution":
+			orderBy = "contribution_score DESC, last_seen DESC"
+		case "checks":
+			orderBy = "checks_per_day DESC, last_seen DESC"
+		case "uptime":
+			orderBy = "uptime_percentage DESC, last_seen DESC"
+		case "last_seen":
+			orderBy = "last_seen DESC"
+		}
+	}
+
+	pageSize := 25
+	page := 1
+	if query != nil {
+		if query.PageSize > 0 {
+			pageSize = query.PageSize
+		}
+		if query.Page > 0 {
+			page = query.Page
+		}
+	}
+	offset := (page - 1) * pageSize
+
+	rows, err := d.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT peer_id, location_country, location_region, location_city, status,
+			checks_per_day, last_seen, uptime_percentage, contribution_score, joined_at
+		FROM peers
+		%s
+		ORDER BY %s
+		LIMIT ? OFFSET ?
+	`, whereClause, orderBy), append(args, pageSize, offset)...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to query peers: %w", err)
+	}
+	defer rows.Close()
+
+	peers := []*models.NetworkPeer{}
+	for rows.Next() {
+		peer, scanErr := scanPeer(rows)
+		if scanErr != nil {
+			return nil, 0, scanErr
+		}
+		peers = append(peers, peer)
+	}
+
+	return peers, total, nil
+}
+
+func (d *LibSQLDatabase) GetPeer(ctx context.Context, peerID string) (*models.NetworkPeer, error) {
+	row := d.db.QueryRowContext(ctx, `
+		SELECT peer_id, location_country, location_region, location_city, status,
+			checks_per_day, last_seen, uptime_percentage, contribution_score, joined_at
+		FROM peers
+		WHERE peer_id = ?
+	`, peerID)
+
+	peer, err := scanPeer(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("peer not found")
+		}
+		return nil, err
+	}
+	return peer, nil
+}
+
+func (d *LibSQLDatabase) GetNetworkHealth(ctx context.Context) (*models.NetworkHealth, error) {
+	health := &models.NetworkHealth{}
+
+	var verifiedCount, peerResultCount int64
+	_ = d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM peer_results WHERE verified = 1").Scan(&verifiedCount)
+	_ = d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM peer_results").Scan(&peerResultCount)
+	if peerResultCount > 0 {
+		health.ConsensusRate = (float64(verifiedCount) / float64(peerResultCount)) * 100
+	}
+
+	var avgLatency sql.NullFloat64
+	_ = d.db.QueryRowContext(ctx, `
+		SELECT AVG(latency_ms) FROM (
+			SELECT latency_ms FROM monitor_results WHERE latency_ms IS NOT NULL
+			UNION ALL
+			SELECT latency_ms FROM peer_results WHERE latency_ms IS NOT NULL
+		)
+	`).Scan(&avgLatency)
+	if avgLatency.Valid {
+		health.AvgLatencyMs = avgLatency.Float64
+	}
+
+	var distinctMonitors, totalPeerResults int64
+	_ = d.db.QueryRowContext(ctx, "SELECT COUNT(DISTINCT monitor_uuid) FROM peer_results").Scan(&distinctMonitors)
+	_ = d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM peer_results").Scan(&totalPeerResults)
+	if distinctMonitors > 0 {
+		health.RedundancyFactor = float64(totalPeerResults) / float64(distinctMonitors)
+	}
+
+	var peersJoinedLastDay, totalPeers int64
+	dayAgo := time.Now().Add(-24 * time.Hour).Unix()
+	_ = d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM peers WHERE joined_at >= ?", dayAgo).Scan(&peersJoinedLastDay)
+	_ = d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM peers").Scan(&totalPeers)
+	if totalPeers > 0 {
+		health.ChurnRate = (float64(peersJoinedLastDay) / float64(totalPeers)) * 100
+	}
+
+	return health, nil
+}
+
+func (d *LibSQLDatabase) GetPeerDistribution(ctx context.Context) ([]*models.RegionStat, error) {
+	rows, err := d.db.QueryContext(ctx, `
+		SELECT
+			COALESCE(NULLIF(location_region, ''), NULLIF(location_country, ''), 'Unknown') AS region,
+			COUNT(*) AS peer_count,
+			SUM(CASE WHEN status = 'online' THEN 1 ELSE 0 END) AS online_count
+		FROM peers
+		GROUP BY 1
+		ORDER BY peer_count DESC, region ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query peer distribution: %w", err)
+	}
+	defer rows.Close()
+
+	regions := []*models.RegionStat{}
+	for rows.Next() {
+		var region models.RegionStat
+		if err := rows.Scan(&region.Region, &region.PeerCount, &region.OnlineCount); err != nil {
+			return nil, fmt.Errorf("failed to scan region stats: %w", err)
+		}
+		regions = append(regions, &region)
+	}
+
+	return regions, nil
+}
+
+func (d *LibSQLDatabase) CreateStatusPage(ctx context.Context, page *models.StatusPage) error {
+	if page.ID == "" {
+		page.ID = generateUUID()
+	}
+
+	now := time.Now().Unix()
+	primaryColor := page.PrimaryColor
+	if primaryColor == "" {
+		primaryColor = "#3B82F6"
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to start transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO status_pages (
+			uuid, title, slug, description, custom_domain, logo_url, primary_color,
+			is_active, visits, user_id, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?, ?)
+	`,
+		page.ID,
+		page.Title,
+		page.Slug,
+		page.Description,
+		page.CustomDomain,
+		page.LogoURL,
+		primaryColor,
+		boolToInt(page.IsActive),
+		now,
+		now,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create status page: %w", err)
+	}
+
+	if err := d.replaceStatusPageMonitors(ctx, tx, page.ID, page.MonitorIDs); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit status page creation: %w", err)
+	}
+
+	return nil
+}
+
+func (d *LibSQLDatabase) GetStatusPage(ctx context.Context, identifier string, bySlug bool) (*models.StatusPage, error) {
+	column := "uuid"
+	if bySlug {
+		column = "slug"
+	}
+
+	query := fmt.Sprintf(`
+		SELECT uuid, title, slug, description, custom_domain, logo_url, primary_color,
+			is_active, visits, created_at, updated_at
+		FROM status_pages
+		WHERE %s = ?
+	`, column)
+
+	row := d.db.QueryRowContext(ctx, query, identifier)
+	page, err := scanStatusPage(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("status page not found")
+		}
+		return nil, err
+	}
+
+	if err := d.hydrateStatusPage(ctx, page); err != nil {
+		return nil, err
+	}
+
+	return page, nil
+}
+
+func (d *LibSQLDatabase) ListStatusPages(ctx context.Context, page, pageSize int, activeOnly bool) ([]*models.StatusPage, int, error) {
+	whereClause := ""
+	args := []interface{}{}
+	if activeOnly {
+		whereClause = "WHERE is_active = 1"
+	}
+
+	var total int
+	if err := d.db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM status_pages %s", whereClause), args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("failed to count status pages: %w", err)
+	}
+
+	if pageSize <= 0 {
+		pageSize = 25
+	}
+	if page <= 0 {
+		page = 1
+	}
+	offset := (page - 1) * pageSize
+
+	rows, err := d.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT uuid, title, slug, description, custom_domain, logo_url, primary_color,
+			is_active, visits, created_at, updated_at
+		FROM status_pages
+		%s
+		ORDER BY created_at DESC
+		LIMIT ? OFFSET ?
+	`, whereClause), append(args, pageSize, offset)...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to query status pages: %w", err)
+	}
+	defer rows.Close()
+
+	pages := []*models.StatusPage{}
+	for rows.Next() {
+		page, scanErr := scanStatusPage(rows)
+		if scanErr != nil {
+			return nil, 0, scanErr
+		}
+		if err := d.hydrateStatusPage(ctx, page); err != nil {
+			return nil, 0, err
+		}
+		pages = append(pages, page)
+	}
+
+	return pages, total, nil
+}
+
+func (d *LibSQLDatabase) UpdateStatusPage(ctx context.Context, id string, update *models.StatusPageUpdate) error {
+	setClauses := []string{}
+	args := []interface{}{}
+
+	if update.Title != nil {
+		setClauses = append(setClauses, "title = ?")
+		args = append(args, *update.Title)
+	}
+	if update.Slug != nil {
+		setClauses = append(setClauses, "slug = ?")
+		args = append(args, *update.Slug)
+	}
+	if update.Description != nil {
+		setClauses = append(setClauses, "description = ?")
+		args = append(args, *update.Description)
+	}
+	if update.IsActive != nil {
+		setClauses = append(setClauses, "is_active = ?")
+		args = append(args, boolToInt(*update.IsActive))
+	}
+	if update.LogoURL != nil {
+		setClauses = append(setClauses, "logo_url = ?")
+		args = append(args, *update.LogoURL)
+	}
+	if update.PrimaryColor != nil {
+		setClauses = append(setClauses, "primary_color = ?")
+		args = append(args, *update.PrimaryColor)
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to start transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	if len(setClauses) > 0 {
+		setClauses = append(setClauses, "updated_at = ?")
+		args = append(args, time.Now().Unix(), id)
+
+		query := fmt.Sprintf("UPDATE status_pages SET %s WHERE uuid = ?", joinStrings(setClauses, ", "))
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("failed to update status page: %w", err)
+		}
+	}
+
+	if update.ReplaceMonitorIDs {
+		if err := d.replaceStatusPageMonitors(ctx, tx, id, update.MonitorIDs); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit status page update: %w", err)
+	}
+	return nil
+}
+
+func (d *LibSQLDatabase) DeleteStatusPage(ctx context.Context, id string) error {
+	_, err := d.db.ExecContext(ctx, "DELETE FROM status_pages WHERE uuid = ?", id)
+	if err != nil {
+		return fmt.Errorf("failed to delete status page: %w", err)
+	}
+	return nil
+}
+
+func (d *LibSQLDatabase) RecordStatusPageVisit(ctx context.Context, id string) error {
+	_, err := d.db.ExecContext(ctx, `
+		UPDATE status_pages
+		SET visits = visits + 1
+		WHERE uuid = ?
+	`, id)
+	if err != nil {
+		return fmt.Errorf("failed to record status page visit: %w", err)
+	}
+	return nil
+}
+
+func (d *LibSQLDatabase) replaceStatusPageMonitors(ctx context.Context, tx *sql.Tx, statusPageID string, monitorIDs []string) error {
+	if _, err := tx.ExecContext(ctx, "DELETE FROM status_page_monitors WHERE status_page_id = ?", statusPageID); err != nil {
+		return fmt.Errorf("failed to clear status page monitors: %w", err)
+	}
+	for index, monitorID := range monitorIDs {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO status_page_monitors (status_page_id, monitor_uuid, display_order)
+			VALUES (?, ?, ?)
+		`, statusPageID, monitorID, index); err != nil {
+			return fmt.Errorf("failed to link monitor to status page: %w", err)
+		}
+	}
+	return nil
+}
+
+type statusPageScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func scanStatusPage(scanner statusPageScanner) (*models.StatusPage, error) {
+	var page models.StatusPage
+	var customDomain, logoURL sql.NullString
+	var isActive int
+	var createdAt, updatedAt int64
+
+	if err := scanner.Scan(
+		&page.ID,
+		&page.Title,
+		&page.Slug,
+		&page.Description,
+		&customDomain,
+		&logoURL,
+		&page.PrimaryColor,
+		&isActive,
+		&page.Visits,
+		&createdAt,
+		&updatedAt,
+	); err != nil {
+		return nil, fmt.Errorf("failed to scan status page: %w", err)
+	}
+
+	page.IsActive = isActive == 1
+	page.CreatedAt = time.Unix(createdAt, 0)
+	page.UpdatedAt = time.Unix(updatedAt, 0)
+	if customDomain.Valid {
+		page.CustomDomain = &customDomain.String
+	}
+	if logoURL.Valid {
+		page.LogoURL = &logoURL.String
+	}
+	if page.PrimaryColor == "" {
+		page.PrimaryColor = "#3B82F6"
+	}
+
+	return &page, nil
+}
+
+func (d *LibSQLDatabase) hydrateStatusPage(ctx context.Context, page *models.StatusPage) error {
+	monitorRows, err := d.db.QueryContext(ctx, `
+		SELECT monitor_uuid
+		FROM status_page_monitors
+		WHERE status_page_id = ?
+		ORDER BY display_order ASC, monitor_uuid ASC
+	`, page.ID)
+	if err != nil {
+		return fmt.Errorf("failed to load status page monitors: %w", err)
+	}
+	defer monitorRows.Close()
+
+	monitorIDs := []string{}
+	for monitorRows.Next() {
+		var monitorID string
+		if err := monitorRows.Scan(&monitorID); err != nil {
+			return fmt.Errorf("failed to scan status page monitor: %w", err)
+		}
+		monitorIDs = append(monitorIDs, monitorID)
+	}
+	page.MonitorIDs = monitorIDs
+
+	if len(monitorIDs) == 0 {
+		return nil
+	}
+
+	placeholders := make([]string, len(monitorIDs))
+	args := make([]interface{}, 0, len(monitorIDs)+1)
+	for i, monitorID := range monitorIDs {
+		placeholders[i] = "?"
+		args = append(args, monitorID)
+	}
+
+	start := time.Now().Add(-30 * 24 * time.Hour).Unix()
+	argsWithStart := append(append([]interface{}{}, args...), start)
+	uptimeQuery := fmt.Sprintf(`
+		SELECT
+			COALESCE(
+				AVG(CASE WHEN status = 'Up' THEN 100.0 ELSE 0.0 END),
+				100.0
+			)
+		FROM monitor_results
+		WHERE monitor_uuid IN (%s)
+		AND timestamp >= ?
+	`, joinStrings(placeholders, ", "))
+	_ = d.db.QueryRowContext(ctx, uptimeQuery, argsWithStart...).Scan(&page.Uptime)
+
+	incidentQuery := fmt.Sprintf(`
+		SELECT COALESCE(MAX(started_at), 0)
+		FROM incidents
+		WHERE monitor_uuid IN (%s)
+	`, joinStrings(placeholders, ", "))
+	var lastIncident int64
+	_ = d.db.QueryRowContext(ctx, incidentQuery, args...).Scan(&lastIncident)
+	if lastIncident > 0 {
+		t := time.Unix(lastIncident, 0)
+		page.LastIncident = &t
+	}
+
+	return nil
+}
+
+type peerScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func scanPeer(scanner peerScanner) (*models.NetworkPeer, error) {
+	var peer models.NetworkPeer
+	var country, region, city sql.NullString
+	var lastSeen, joinedAt int64
+
+	if err := scanner.Scan(
+		&peer.PeerID,
+		&country,
+		&region,
+		&city,
+		&peer.Status,
+		&peer.ChecksPerDay,
+		&lastSeen,
+		&peer.UptimePercentage,
+		&peer.ContributionScore,
+		&joinedAt,
+	); err != nil {
+		return nil, fmt.Errorf("failed to scan peer: %w", err)
+	}
+
+	peer.LastSeen = time.Unix(lastSeen, 0)
+	peer.JoinedAt = time.Unix(joinedAt, 0)
+	peer.Location = &commonv1.Location{
+		Country: country.String,
+		Region:  region.String,
+		City:    city.String,
+	}
+
+	return &peer, nil
+}
+
+// Exec executes a raw SQL statement
+func (d *LibSQLDatabase) Exec(ctx context.Context, query string) error {
+	_, err := d.db.ExecContext(ctx, query)
+	return err
+}

--- a/apps/server/internal/db/types.go
+++ b/apps/server/internal/db/types.go
@@ -1,0 +1,56 @@
+package db
+
+import (
+	"context"
+	"time"
+
+	"github.com/Obiente/Uppe/apps/server/internal/db/types"
+	"github.com/Obiente/Uppe/apps/server/internal/models"
+)
+
+// Database defines the interface for database operations
+// This allows us to support multiple database backends (LibSQL, PostgreSQL, TimescaleDB)
+type Database interface {
+	// Monitor operations
+	CreateMonitor(ctx context.Context, monitor *models.Monitor) error
+	GetMonitor(ctx context.Context, id string) (*models.Monitor, error)
+	ListMonitors(ctx context.Context, filters *types.MonitorFilters) ([]*models.Monitor, int, error)
+	UpdateMonitor(ctx context.Context, id string, updates *models.MonitorUpdate) error
+	DeleteMonitor(ctx context.Context, id string) error
+	GetMonitorStats(ctx context.Context, monitorID string, startTime, endTime time.Time) (*models.MonitorStats, error)
+
+	// Result operations
+	SaveResult(ctx context.Context, result *models.MonitoringResult) error
+	GetResults(ctx context.Context, query *types.ResultQuery) ([]*models.MonitoringResult, int, error)
+	GetAggregatedStats(ctx context.Context, monitorID string, startTime, endTime time.Time, period types.AggregationPeriod) ([]*models.TimeSeriesDataPoint, error)
+
+	// Global ping samples across nodes/locations for a monitor
+	GetGlobalPingSamples(ctx context.Context, monitorID string, startTime, endTime time.Time) ([]*models.MonitoringResult, error)
+
+	// Settings operations
+	GetSetting(ctx context.Context, key string) (string, bool, error)
+	SetSetting(ctx context.Context, key string, value string) error
+	GetNodeIdentity(ctx context.Context) (*models.NodeIdentity, error)
+
+	// Network operations
+	GetNetworkStats(ctx context.Context) (*models.NetworkStats, error)
+	ListPeers(ctx context.Context, query *types.PeerQuery) ([]*models.NetworkPeer, int, error)
+	GetPeer(ctx context.Context, peerID string) (*models.NetworkPeer, error)
+	GetNetworkHealth(ctx context.Context) (*models.NetworkHealth, error)
+	GetPeerDistribution(ctx context.Context) ([]*models.RegionStat, error)
+
+	// Status page operations
+	CreateStatusPage(ctx context.Context, page *models.StatusPage) error
+	GetStatusPage(ctx context.Context, identifier string, bySlug bool) (*models.StatusPage, error)
+	ListStatusPages(ctx context.Context, page, pageSize int, activeOnly bool) ([]*models.StatusPage, int, error)
+	UpdateStatusPage(ctx context.Context, id string, update *models.StatusPageUpdate) error
+	DeleteStatusPage(ctx context.Context, id string) error
+	RecordStatusPageVisit(ctx context.Context, id string) error
+
+	// Health check
+	Ping(ctx context.Context) error
+	Close() error
+
+	// Migration support
+	Exec(ctx context.Context, query string) error
+}

--- a/apps/server/internal/db/types/types.go
+++ b/apps/server/internal/db/types/types.go
@@ -1,0 +1,39 @@
+package types
+
+import "time"
+
+// MonitorFilters for listing monitors
+type MonitorFilters struct {
+	UserID     *string
+	Enabled    *bool
+	Visibility *string // Optional filter: "Public", "Private", "Internal"
+	Page       int
+	PageSize   int
+}
+
+// ResultQuery for querying results
+type ResultQuery struct {
+	MonitorID string
+	StartTime time.Time
+	EndTime   time.Time
+	Limit     int
+	Offset    int
+}
+
+// PeerQuery for querying peers in the network view
+type PeerQuery struct {
+	Page         int
+	PageSize     int
+	SortBy       string
+	FilterStatus string
+}
+
+// AggregationPeriod for time-series aggregation
+type AggregationPeriod string
+
+const (
+	AggregationPeriodHour  AggregationPeriod = "hour"
+	AggregationPeriodDay   AggregationPeriod = "day"
+	AggregationPeriodWeek  AggregationPeriod = "week"
+	AggregationPeriodMonth AggregationPeriod = "month"
+)

--- a/apps/server/internal/models/network.go
+++ b/apps/server/internal/models/network.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"time"
+
+	commonv1 "github.com/Obiente/Uppe/apps/server/gen/common/v1"
+)
+
+// NetworkStats represents aggregate P2P network metrics.
+type NetworkStats struct {
+	TotalPeers           int64
+	OnlinePeers          int64
+	ChecksPerHour        int64
+	CoveragePercentage   float64
+	ShareRatio           float64
+	MonitoringForOthers  int64
+	ReceivingFromOthers  int64
+	ContributionScore    float64
+	MyNodeID             string
+	BandwidthUsedMb      int64
+	BandwidthLimitMb     int64
+	ChecksPerformedToday int64
+	ChecksReceivedToday  int64
+}
+
+// NetworkPeer represents a peer in the distributed network.
+type NetworkPeer struct {
+	PeerID            string
+	Location          *commonv1.Location
+	Status            string
+	ChecksPerDay      int64
+	LastSeen          time.Time
+	UptimePercentage  float64
+	ContributionScore float64
+	JoinedAt          time.Time
+}
+
+// NetworkHealth captures coarse health indicators derived from replicated data.
+type NetworkHealth struct {
+	ConsensusRate    float64
+	AvgLatencyMs     float64
+	RedundancyFactor float64
+	ChurnRate        float64
+}
+
+// RegionStat aggregates peer counts by region.
+type RegionStat struct {
+	Region       string
+	PeerCount    int64
+	OnlineCount  int64
+	AvgLatencyMs float64
+}

--- a/apps/server/internal/models/status_page.go
+++ b/apps/server/internal/models/status_page.go
@@ -1,0 +1,33 @@
+package models
+
+import "time"
+
+// StatusPage represents a public status page persisted in the shared database.
+type StatusPage struct {
+	ID           string
+	Title        string
+	Slug         string
+	Description  string
+	CustomDomain *string
+	MonitorIDs   []string
+	IsActive     bool
+	LogoURL      *string
+	PrimaryColor string
+	Uptime       float64
+	Visits       int64
+	LastIncident *time.Time
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// StatusPageUpdate represents mutable status page fields.
+type StatusPageUpdate struct {
+	Title             *string
+	Slug              *string
+	Description       *string
+	MonitorIDs        []string
+	ReplaceMonitorIDs bool
+	IsActive          *bool
+	LogoURL           *string
+	PrimaryColor      *string
+}

--- a/apps/server/internal/server/server.go
+++ b/apps/server/internal/server/server.go
@@ -1,0 +1,127 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+
+	monitorv1connect "github.com/Obiente/Uppe/apps/server/gen/monitor/v1/monitorv1connect"
+	networkv1connect "github.com/Obiente/Uppe/apps/server/gen/network/v1/networkv1connect"
+	resultv1connect "github.com/Obiente/Uppe/apps/server/gen/result/v1/resultv1connect"
+	settingsv1connect "github.com/Obiente/Uppe/apps/server/gen/settings/v1/settingsv1connect"
+	statuspagev1connect "github.com/Obiente/Uppe/apps/server/gen/statuspage/v1/statuspagev1connect"
+	"github.com/Obiente/Uppe/apps/server/internal/config"
+	monitorservice "github.com/Obiente/Uppe/apps/server/internal/connect/monitor"
+	networkservice "github.com/Obiente/Uppe/apps/server/internal/connect/network"
+	resultservice "github.com/Obiente/Uppe/apps/server/internal/connect/result"
+	settingsservice "github.com/Obiente/Uppe/apps/server/internal/connect/settings"
+	statuspageservice "github.com/Obiente/Uppe/apps/server/internal/connect/statuspage"
+	"github.com/Obiente/Uppe/apps/server/internal/db"
+)
+
+type Server struct {
+	httpServer *http.Server
+	logger     *zap.Logger
+	database   db.Database
+}
+
+// CORS middleware to allow requests from the frontend
+func corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Allow requests from localhost during development
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			origin = "*"
+		}
+
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Connect-Protocol-Version, Connect-Timeout-Ms")
+		w.Header().Set("Access-Control-Expose-Headers", "Connect-Protocol-Version")
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+
+		// Handle preflight requests
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func New(cfg *config.Config, logger *zap.Logger) (*Server, error) {
+	// Initialize database
+	database, err := db.NewDatabase(&cfg.Database)
+	if err != nil {
+		return nil, err
+	}
+
+	// Test database connection
+	if err := database.Ping(context.Background()); err != nil {
+		return nil, err
+	}
+
+	// Create HTTP mux
+	mux := http.NewServeMux()
+
+	// Create service handlers with database
+	monitorService := monitorservice.NewMonitorService(logger, database)
+	networkService := networkservice.NewNetworkService(logger, database)
+	resultService := resultservice.NewResultService(logger, database)
+	settingsService := settingsservice.NewSettingsService(logger, database)
+	statusPageService := statuspageservice.NewStatusPageService(logger, database)
+
+	// Register ConnectRPC handlers
+	monitorPath, monitorHandler := monitorv1connect.NewMonitorServiceHandler(monitorService)
+	networkPath, networkHandler := networkv1connect.NewNetworkServiceHandler(networkService)
+	resultPath, resultHandler := resultv1connect.NewResultServiceHandler(resultService)
+	settingsPath, settingsHandler := settingsv1connect.NewSettingsServiceHandler(settingsService)
+	statusPagePath, statusPageHandler := statuspagev1connect.NewStatusPageServiceHandler(statusPageService)
+
+	mux.Handle(monitorPath, monitorHandler)
+	mux.Handle(networkPath, networkHandler)
+	mux.Handle(resultPath, resultHandler)
+	mux.Handle(settingsPath, settingsHandler)
+	mux.Handle(statusPagePath, statusPageHandler)
+
+	// Health check endpoint
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+
+	// Create HTTP server with h2c (HTTP/2 Cleartext) for gRPC
+	httpServer := &http.Server{
+		Addr:         cfg.ServerAddress(),
+		Handler:      corsMiddleware(h2c.NewHandler(mux, &http2.Server{})),
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	return &Server{
+		httpServer: httpServer,
+		logger:     logger,
+		database:   database,
+	}, nil
+}
+
+func (s *Server) Start() error {
+	s.logger.Info("Server starting",
+		zap.String("address", s.httpServer.Addr),
+	)
+	return s.httpServer.ListenAndServe()
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.logger.Info("Server shutting down")
+	if err := s.database.Close(); err != nil {
+		s.logger.Error("Failed to close database", zap.Error(err))
+	}
+	return s.httpServer.Shutdown(ctx)
+}


### PR DESCRIPTION
## Summary
- add architecture and agent guidance docs for roadmap execution
- wire real ConnectRPC settings, network, and status page services into the Go API
- back those services with the Rust-owned shared database schema
- replace placeholder settings, network, and status page management pages with live API-backed Astro pages

## Testing
- go test ./...
- frontend build not run in this shell because node is unavailable

Closes #32
Closes #33
Partially addresses #27
Partially addresses #28
Partially addresses #29
Partially addresses #34