### PR TITLE
Implement public and editable status page flows

### DIFF
--- a/apps/client/src/components/StatusPageForm.astro
+++ b/apps/client/src/components/StatusPageForm.astro
@@ -1,0 +1,274 @@
+---
+import Button from './ui/Button.astro';
+
+interface MonitorOption {
+  id: string;
+  name: string;
+  url?: string;
+}
+
+interface ExistingPage {
+  id: string;
+  title: string;
+  slug: string;
+  description?: string;
+  logoUrl?: string;
+  isActive: boolean;
+  monitorIds: string[];
+}
+
+interface Props {
+  mode: 'create' | 'edit';
+  monitors: MonitorOption[];
+  page?: ExistingPage | null;
+}
+
+const { mode, monitors, page = null } = Astro.props;
+const isEdit = mode === 'edit';
+const pageId = page?.id ?? '';
+const originalSlug = page?.slug ?? '';
+---
+
+<div
+  id="statusPageFormRoot"
+  data-mode={mode}
+  data-page-id={pageId}
+  data-original-slug={originalSlug}
+  class="space-y-5"
+>
+  <div id="formMsg" class="hidden rounded-lg px-4 py-3 text-sm font-medium"></div>
+
+  <form id="statusPageForm" class="space-y-5">
+    <div class="rounded-xl border border-primary bg-bg-secondary overflow-hidden">
+      <div class="px-5 py-3.5 border-b border-primary">
+        <p class="text-sm font-semibold text-primary">Status Page Details</p>
+      </div>
+      <div class="px-5 py-5 space-y-4">
+        <div>
+          <label for="title" class="block text-sm text-secondary mb-1.5">
+            Title <span style="color: #eb6f92;">*</span>
+          </label>
+          <input
+            id="title"
+            name="title"
+            type="text"
+            required
+            value={page?.title ?? ''}
+            placeholder="Production API Status"
+            class="w-full rounded-lg border border-primary px-3 py-2 text-sm text-primary placeholder-secondary focus:outline-none focus:border-accent-primary/60 transition-colors"
+            style="background: #26233a;"
+          />
+        </div>
+
+        <div>
+          <label for="slug" class="block text-sm text-secondary mb-1.5">
+            Slug <span style="color: #eb6f92;">*</span>
+          </label>
+          <input
+            id="slug"
+            name="slug"
+            type="text"
+            required
+            value={page?.slug ?? ''}
+            placeholder="production-api"
+            class="w-full rounded-lg border border-primary px-3 py-2 text-sm text-primary font-mono placeholder-secondary focus:outline-none focus:border-accent-primary/60 transition-colors"
+            style="background: #26233a;"
+          />
+          <p class="text-xs text-secondary mt-1">Lowercase letters, numbers, and hyphens only.</p>
+        </div>
+
+        <div>
+          <label for="description" class="block text-sm text-secondary mb-1.5">Description</label>
+          <textarea
+            id="description"
+            name="description"
+            rows="3"
+            placeholder="Real-time status and uptime monitoring for our production systems."
+            class="w-full rounded-lg border border-primary px-3 py-2 text-sm text-primary placeholder-secondary focus:outline-none focus:border-accent-primary/60 transition-colors"
+            style="background: #26233a;"
+          >{page?.description ?? ''}</textarea>
+        </div>
+
+        <div>
+          <label for="logoUrl" class="block text-sm text-secondary mb-1.5">Logo URL</label>
+          <input
+            id="logoUrl"
+            name="logoUrl"
+            type="url"
+            value={page?.logoUrl ?? ''}
+            placeholder="https://example.com/logo.png"
+            class="w-full rounded-lg border border-primary px-3 py-2 text-sm text-primary placeholder-secondary focus:outline-none focus:border-accent-primary/60 transition-colors"
+            style="background: #26233a;"
+          />
+        </div>
+
+        <div class="flex items-center justify-between pt-2">
+          <div>
+            <p class="text-sm text-primary font-medium">Publish this page</p>
+            <p class="text-xs text-secondary mt-0.5">Inactive pages stay editable but do not present as operational.</p>
+          </div>
+          <label class="relative inline-flex items-center cursor-pointer">
+            <input
+              type="checkbox"
+              id="isPublished"
+              name="isPublished"
+              class="sr-only peer"
+              checked={page?.isActive ?? true}
+            />
+            <div class="w-9 h-5 rounded-full peer-checked:bg-status-success bg-bg-tertiary border border-primary transition-colors peer-focus:outline-none after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-4" style="border-color: #393552;"></div>
+          </label>
+        </div>
+      </div>
+    </div>
+
+    <div class="rounded-xl border border-primary bg-bg-secondary overflow-hidden">
+      <div class="px-5 py-3.5 border-b border-primary">
+        <p class="text-sm font-semibold text-primary">Included Monitors</p>
+        <p class="text-xs text-secondary mt-0.5">Choose which services appear on the public page.</p>
+      </div>
+      <div class="px-5 py-5 space-y-3">
+        {monitors.length > 0 ? monitors.map((monitor) => (
+          <label class="flex items-start justify-between gap-4 rounded-lg border border-primary px-4 py-3 cursor-pointer hover:border-accent-primary/30 transition-colors" style="background: #26233a;">
+            <div class="min-w-0">
+              <p class="text-sm font-medium text-primary">{monitor.name}</p>
+              <p class="text-xs text-secondary font-mono truncate">{monitor.url ?? monitor.id}</p>
+            </div>
+            <input
+              class="mt-1"
+              type="checkbox"
+              name="monitorIds"
+              value={monitor.id}
+              checked={page?.monitorIds.includes(monitor.id)}
+            />
+          </label>
+        )) : (
+          <p class="text-sm text-secondary">No monitors are available yet.</p>
+        )}
+      </div>
+    </div>
+
+    <div class="flex items-center justify-between gap-3">
+      <div>
+        {isEdit && (
+          <Button id="deleteStatusPageBtn" variant="danger" size="sm" type="button">
+            Delete Page
+          </Button>
+        )}
+      </div>
+      <div class="flex items-center gap-3">
+        <Button variant="secondary" size="sm" href="/status-pages">
+          Cancel
+        </Button>
+        <Button id="submitStatusPageBtn" variant="primary" size="sm" type="submit" disabled={monitors.length === 0}>
+          {isEdit ? 'Save Changes' : 'Create Status Page'}
+        </Button>
+      </div>
+    </div>
+  </form>
+</div>
+
+<script>
+  import {
+    createStatusPage,
+    deleteStatusPage,
+    updateStatusPage,
+    validateSlug,
+  } from '../lib/services/statusPageService';
+
+  const root = document.getElementById('statusPageFormRoot') as HTMLElement | null;
+  const form = document.getElementById('statusPageForm') as HTMLFormElement | null;
+  const submitBtn = document.getElementById('submitStatusPageBtn') as HTMLButtonElement | null;
+  const deleteBtn = document.getElementById('deleteStatusPageBtn') as HTMLButtonElement | null;
+  const formMsg = document.getElementById('formMsg') as HTMLElement | null;
+
+  const mode = root?.dataset.mode ?? 'create';
+  const pageId = root?.dataset.pageId ?? '';
+  const originalSlug = root?.dataset.originalSlug ?? '';
+
+  function showMsg(msg: string, isError: boolean) {
+    if (!formMsg) return;
+    formMsg.textContent = msg;
+    formMsg.className = `rounded-lg px-4 py-3 text-sm font-medium ${isError
+      ? 'text-status-error bg-status-error/10 border border-status-error/20'
+      : 'text-status-success bg-status-success/10 border border-status-success/20'}`;
+    formMsg.classList.remove('hidden');
+  }
+
+  form?.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!form || !submitBtn) return;
+
+    submitBtn.disabled = true;
+    submitBtn.textContent = mode === 'edit' ? 'Saving…' : 'Creating…';
+    formMsg?.classList.add('hidden');
+
+    try {
+      const formData = new FormData(form);
+      const title = String(formData.get('title') ?? '').trim();
+      const slug = String(formData.get('slug') ?? '').trim();
+      const description = String(formData.get('description') ?? '').trim();
+      const logoUrl = String(formData.get('logoUrl') ?? '').trim();
+      const isPublished = formData.get('isPublished') === 'on';
+      const monitorIds = formData.getAll('monitorIds').map((value) => String(value));
+
+      if (!title || !slug) {
+        throw new Error('Title and slug are required.');
+      }
+      if (monitorIds.length === 0) {
+        throw new Error('Select at least one monitor for the status page.');
+      }
+
+      const slugCheck = await validateSlug(slug, originalSlug);
+      if (!slugCheck.valid) {
+        throw new Error(slugCheck.message ?? 'Slug validation failed.');
+      }
+
+      if (mode === 'edit') {
+        const result = await updateStatusPage(pageId, {
+          name: title,
+          slug,
+          description,
+          monitorIds,
+          isPublished,
+          companyLogo: logoUrl || undefined,
+        });
+        if (!result.success) {
+          throw new Error(result.error ?? 'Failed to update status page.');
+        }
+      } else {
+        const result = await createStatusPage({
+          name: title,
+          slug,
+          description,
+          monitorIds,
+          companyName: undefined,
+          logoUrl: logoUrl || undefined,
+        });
+        if (!result.success) {
+          throw new Error(result.error ?? 'Failed to create status page.');
+        }
+      }
+
+      window.location.href = '/status-pages';
+    } catch (error: any) {
+      showMsg(error?.message ?? 'Unable to save status page.', true);
+      submitBtn.disabled = false;
+      submitBtn.textContent = mode === 'edit' ? 'Save Changes' : 'Create Status Page';
+    }
+  });
+
+  deleteBtn?.addEventListener('click', async () => {
+    if (!pageId) return;
+    const confirmed = window.confirm('Delete this status page? This cannot be undone.');
+    if (!confirmed) return;
+
+    try {
+      deleteBtn.disabled = true;
+      await deleteStatusPage(pageId);
+      window.location.href = '/status-pages';
+    } catch (error: any) {
+      showMsg(error?.message ?? 'Unable to delete status page.', true);
+      deleteBtn.disabled = false;
+    }
+  });
+</script>

--- a/apps/client/src/components/ui/StatusPageCard.astro
+++ b/apps/client/src/components/ui/StatusPageCard.astro
@@ -23,6 +23,7 @@ interface Props {
   visits: number;
   lastIncident: string;
   created: string;
+  editHref?: string;
 }
 
 const {
@@ -34,6 +35,7 @@ const {
   visits,
   lastIncident,
   created,
+  editHref = `/status-pages/${slug}/edit`,
 } = Astro.props;
 
 // Format date for better display
@@ -187,7 +189,7 @@ const getDomain = () => {
           href={`/public/${slug}`}
           class="my-auto"
         />
-        <Button variant="secondary" size="sm"> Edit </Button>
+        <Button variant="secondary" size="sm" href={editHref}> Edit </Button>
       </Flex>
     </Flex>
   </CardBody>

--- a/apps/client/src/lib/services/statusPageService.ts
+++ b/apps/client/src/lib/services/statusPageService.ts
@@ -97,6 +97,7 @@ export async function createStatusPage(data: {
   monitorIds: string[];
   companyName?: string;
   customDomain?: string;
+  logoUrl?: string;
 }): Promise<{ success: boolean; page?: StatusPage; error?: string }> {
   try {
     const created = await statusPageClient.createStatusPage(new CreateStatusPageRequest({
@@ -104,6 +105,7 @@ export async function createStatusPage(data: {
       slug: data.slug,
       description: data.description ?? '',
       monitorIds: data.monitorIds,
+      logoUrl: data.logoUrl ?? '',
     }));
 
     return {
@@ -168,15 +170,15 @@ export async function updateStatusPage(
   data: Partial<StatusPage>
 ): Promise<{ success: boolean; page?: StatusPage; error?: string }> {
   try {
-    const updated = await statusPageClient.updateStatusPage(new UpdateStatusPageRequest({
-      id,
-      title: data.name,
-      slug: data.slug,
-      description: data.description,
-      monitorIds: data.monitorIds ?? [],
-      isActive: data.isPublished,
-      logoUrl: data.companyLogo,
-    }));
+    const request: any = { id };
+    if (data.name !== undefined) request.title = data.name;
+    if (data.slug !== undefined) request.slug = data.slug;
+    if (data.description !== undefined) request.description = data.description;
+    if (data.monitorIds !== undefined) request.monitorIds = data.monitorIds;
+    if (data.isPublished !== undefined) request.isActive = data.isPublished;
+    if (data.companyLogo !== undefined) request.logoUrl = data.companyLogo;
+
+    const updated = await statusPageClient.updateStatusPage(new UpdateStatusPageRequest(request));
 
     return {
       success: true,
@@ -244,7 +246,7 @@ export async function getMonitorUptime(
   };
 }
 
-export async function validateSlug(slug: string): Promise<{
+export async function validateSlug(slug: string, currentSlug?: string): Promise<{
   valid: boolean;
   message?: string;
 }> {
@@ -264,9 +266,12 @@ export async function validateSlug(slug: string): Promise<{
   }
 
   try {
-    await statusPageClient.getStatusPage(new GetStatusPageRequest({
+    const existing = await statusPageClient.getStatusPage(new GetStatusPageRequest({
       identifier: { case: 'slug', value: slug },
     }));
+    if (currentSlug && existing.slug === currentSlug) {
+      return { valid: true };
+    }
     return {
       valid: false,
       message: 'Slug is already in use',

--- a/apps/client/src/pages/public/[slug].astro
+++ b/apps/client/src/pages/public/[slug].astro
@@ -3,6 +3,15 @@ import Layout from '../../layouts/Layout.astro';
 import UptimeChart from '../../components/UptimeChart.astro';
 import GlobalPingMap from '../../components/GlobalPingMap.astro';
 import IncidentList from '../../components/IncidentList.astro';
+import { monitorClient, resultClient, statusPageClient } from '../../lib/api/client';
+import {
+  AggregationPeriod,
+  GetAggregatedStatsRequest,
+  GetGlobalPingRequest,
+  GetResultsRequest,
+  ResultStatus,
+} from '../../gen/result/v1/result_pb';
+import { GetStatusPageRequest, RecordVisitRequest } from '../../gen/statuspage/v1/statuspage_pb';
 import { 
   Section, 
   Grid, 
@@ -15,80 +24,220 @@ import {
   Badge
 } from "../../components/ui";
 
-export async function getStaticPaths() {
-  // In a real app, this would fetch from your API or database
-  return [
-    { params: { slug: 'production-api' } },
-    { params: { slug: 'website' } },
-    { params: { slug: 'database' } }
-  ];
+const { slug } = Astro.params;
+if (!slug) {
+  return Astro.redirect('/status-pages');
 }
 
-const { slug } = Astro.params;
+const now = Math.floor(Date.now() / 1000);
+const dayAgo = now - 24 * 60 * 60;
 
-// Mock public status page data - in real app, this would come from API
-const statusPage = {
-	slug: slug,
-	title: 'Production API Status',
-	description: 'Real-time status and uptime monitoring for our production API service',
-	url: 'https://api.example.com',
-	status: 'online',
-	uptime: 99.97,
-	avgResponseTime: 142,
-	lastCheck: '2024-01-15T10:30:00Z',
-	monitoringPeers: 12,
-	owner: 'Example Corp',
-	logo: '/logo.png',
-	customBranding: {
-		primaryColor: '#eb6f92',
-		backgroundColor: '#191724',
-		textColor: '#e0def4'
-	}
+let statusPage: any = null;
+let notFound = false;
+
+try {
+  statusPage = await statusPageClient.getStatusPage(new GetStatusPageRequest({
+    identifier: { case: 'slug', value: slug },
+  }));
+  await statusPageClient.recordVisit(new RecordVisitRequest({ statusPageId: statusPage.id }));
+} catch {
+  notFound = true;
+  Astro.response.status = 404;
+}
+
+const formatLocation = (location: any, fallback: string) => {
+  const parts = [location?.city, location?.region, location?.country].filter(Boolean);
+  return parts.length > 0 ? parts.join(', ') : fallback;
 };
 
-const uptimeData = [99.5, 99.8, 99.2, 99.9, 99.6, 99.7, 99.9, 99.8, 99.5, 99.3, 99.7, 99.8, 99.9, 99.6, 99.4, 99.7, 99.8, 99.9, 99.5, 99.6, 99.8, 99.7, 99.9, 99.8];
+const statusFromResult = (result: any) => {
+  switch (result?.status) {
+    case ResultStatus.UP:
+      return 'online';
+    case ResultStatus.DEGRADED:
+      return 'degraded';
+    case ResultStatus.DOWN:
+    case ResultStatus.TIMEOUT:
+    case ResultStatus.ERROR:
+      return 'offline';
+    default:
+      return 'unknown';
+  }
+};
+
+const globalPingStatus = (status: ResultStatus) => {
+  switch (status) {
+    case ResultStatus.UP:
+      return 'online' as const;
+    case ResultStatus.TIMEOUT:
+      return 'timeout' as const;
+    default:
+      return 'error' as const;
+  }
+};
+
+let monitorSummaries: any[] = [];
+let uptimeData: number[] = Array.from({ length: 24 }, () => Number(statusPage?.uptime ?? 100));
+let peerData: any[] = [];
+let recentIncidents: any[] = [];
+let overallStatus: 'online' | 'offline' | 'degraded' | 'maintenance' | 'unknown' = 'unknown';
+let avgResponseTime = 0;
+let monitoringPeers = 0;
+let primaryMetric = 'No monitors linked';
+let lastUpdatedAt = new Date(Number(statusPage?.updatedAt ?? now) * 1000).toISOString();
+
+if (!notFound && statusPage) {
+  const monitorDataResults = await Promise.allSettled(
+    statusPage.monitorIds.map(async (monitorId: string) => {
+      const [monitor, latestResults, stats, globalPing] = await Promise.all([
+        monitorClient.getMonitor({ id: monitorId }),
+        resultClient.getResults(new GetResultsRequest({
+          monitorId,
+          startTime: dayAgo,
+          endTime: now,
+          limit: 1,
+          offset: 0,
+        })),
+        resultClient.getAggregatedStats(new GetAggregatedStatsRequest({
+          monitorId,
+          startTime: dayAgo,
+          endTime: now,
+          period: AggregationPeriod.HOUR,
+        })),
+        resultClient.getGlobalPing(new GetGlobalPingRequest({
+          monitorId,
+          startTime: dayAgo,
+          endTime: now,
+        })),
+      ]);
+
+      return {
+        monitor,
+        latestResult: latestResults.results[0],
+        stats: stats.dataPoints,
+        globalPing: globalPing.samples,
+      };
+    })
+  );
+
+  const monitorData = monitorDataResults
+    .filter((result) => result.status === 'fulfilled')
+    .map((result: any) => result.value);
+
+  monitorSummaries = monitorData.map((entry) => ({
+    id: entry.monitor.id,
+    name: entry.monitor.publicDisplayName || entry.monitor.name,
+    url: entry.monitor.url,
+    status: statusFromResult(entry.latestResult),
+    latestResult: entry.latestResult,
+  }));
+
+  const latestTimestamps = monitorData
+    .map((entry) => Number(entry.latestResult?.timestamp ?? 0))
+    .filter((value) => value > 0);
+  if (latestTimestamps.length > 0) {
+    lastUpdatedAt = new Date(Math.max(...latestTimestamps) * 1000).toISOString();
+  }
+
+  const latestLatencies = monitorData
+    .map((entry) => Number(entry.latestResult?.latencyMs ?? 0))
+    .filter((value) => value > 0);
+  avgResponseTime = latestLatencies.length > 0
+    ? Math.round(latestLatencies.reduce((sum, value) => sum + value, 0) / latestLatencies.length)
+    : 0;
+
+  const statusValues = monitorSummaries.map((entry) => entry.status);
+  if (statusValues.length === 0) {
+    overallStatus = 'unknown';
+  } else if (statusValues.some((status) => status === 'offline')) {
+    overallStatus = 'offline';
+  } else if (statusValues.some((status) => status === 'degraded')) {
+    overallStatus = 'degraded';
+  } else if (statusValues.every((status) => status === 'online')) {
+    overallStatus = 'online';
+  }
+
+  const hourlyBuckets = new Map<number, number[]>();
+  for (const entry of monitorData) {
+    for (const point of entry.stats) {
+      const timestamp = Number(point.timestamp ?? 0);
+      const bucket = Math.floor((now - timestamp) / 3600);
+      if (bucket < 0 || bucket >= 24) continue;
+      const values = hourlyBuckets.get(bucket) ?? [];
+      values.push(Number(point.uptimePercentage ?? 0));
+      hourlyBuckets.set(bucket, values);
+    }
+  }
+
+  uptimeData = Array.from({ length: 24 }, (_, index) => {
+    const bucket = 23 - index;
+    const values = hourlyBuckets.get(bucket);
+    if (!values || values.length === 0) return Number(statusPage.uptime ?? 100);
+    return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length);
+  });
+
+  const pingSamples = monitorData.flatMap((entry) => entry.globalPing);
+  const latestByPeer = new Map<string, any>();
+  for (const sample of pingSamples) {
+    const existing = latestByPeer.get(sample.peerId);
+    if (!existing || Number(sample.timestamp ?? 0) > Number(existing.timestamp ?? 0)) {
+      latestByPeer.set(sample.peerId, sample);
+    }
+  }
+
+  peerData = Array.from(latestByPeer.values()).map((sample) => ({
+    id: sample.peerId,
+    location: formatLocation(sample.location, sample.peerId.slice(0, 8)),
+    latitude: 0,
+    longitude: 0,
+    ping: Number(sample.latencyMs ?? 0),
+    status: globalPingStatus(sample.status),
+    lastCheck: new Date(Number(sample.timestamp ?? 0) * 1000).toLocaleString(),
+  }));
+  monitoringPeers = peerData.length;
+
+  primaryMetric = monitorSummaries.length === 1
+    ? monitorSummaries[0].url
+    : `${monitorSummaries.length} services`;
+
+  if (Number(statusPage.lastIncident ?? 0) > 0) {
+    const incidentTime = new Date(Number(statusPage.lastIncident) * 1000);
+    recentIncidents = [{
+      id: `incident-${statusPage.id}`,
+      title: 'Recent incident detected',
+      description: 'A recent incident timestamp exists for this status page. Detailed incident timelines are not exposed yet.',
+      status: 'resolved' as const,
+      time: incidentTime.toLocaleString(),
+      duration: 'Unavailable',
+    }];
+  }
+}
+
+const pageTitle = `${statusPage?.title ?? 'Status Page'} - Status Page`;
+const metaDescription = `${statusPage?.description ?? 'Status page'} - Current uptime: ${Number(statusPage?.uptime ?? 100).toFixed(2)}%`;
 const hours = Array.from({ length: 24 }, (_, i) => i);
-
-const peerData = [
-	{ id: '1', location: 'New York, US', latitude: 40.7128, longitude: -74.0060, ping: 45, status: 'online' as const, lastCheck: '2024-01-15T10:30:00Z' },
-	{ id: '2', location: 'London, UK', latitude: 51.5074, longitude: -0.1278, ping: 78, status: 'online' as const, lastCheck: '2024-01-15T10:30:00Z' },
-	{ id: '3', location: 'Tokyo, JP', latitude: 35.6762, longitude: 139.6503, ping: 125, status: 'online' as const, lastCheck: '2024-01-15T10:30:00Z' },
-	{ id: '4', location: 'Sydney, AU', latitude: -33.8688, longitude: 151.2093, ping: 189, status: 'timeout' as const, lastCheck: '2024-01-15T10:29:00Z' },
-	{ id: '5', location: 'São Paulo, BR', latitude: -23.5505, longitude: -46.6333, ping: 156, status: 'online' as const, lastCheck: '2024-01-15T10:30:00Z' }
-];
-
-const recentIncidents = [
-	{
-		id: '1',
-		title: 'API Response Timeout',
-		description: 'Increased response times detected from multiple monitoring peers',
-		status: 'resolved' as const,
-		time: '2024-01-12T14:23:00Z',
-		duration: '24 minutes'
-	},
-	{
-		id: '2',
-		title: 'Service Unreachable',
-		description: 'Service completely unreachable from European peers',
-		status: 'resolved' as const,
-		time: '2024-01-10T08:15:00Z',
-		duration: '8 minutes'
-	}
-];
-
-const pageTitle = `${statusPage.title} - Status Page`;
-const metaDescription = `${statusPage.description} - Current uptime: ${statusPage.uptime}%`;
 ---
 
 <Layout title={pageTitle}>
-	<div class="min-h-screen bg-surface-primary text-primary">
+	<div class="min-h-screen bg-surface-primary text-primary" style={`--brand-primary: ${statusPage?.primaryColor ?? '#c4a7e7'}`}>
+    {notFound || !statusPage ? (
+      <main class="max-w-4xl mx-auto px-6 py-16">
+        <Card>
+          <CardBody>
+            <Heading level={2} class="mb-3">Status page not found</Heading>
+            <Paragraph class="text-secondary">No published status page exists for <code class="font-mono">{slug}</code>.</Paragraph>
+          </CardBody>
+        </Card>
+      </main>
+    ) : (
+    <>
 		<!-- Header -->
 		<header class="border-b border-primary bg-surface-primary">
 			<div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
 				<div class="flex items-center justify-between">
 					<div class="flex items-center gap-4">
-						{statusPage.logo && (
-							<img src={statusPage.logo} alt={statusPage.owner} class="w-8 h-8 rounded" />
+						{statusPage.logoUrl && (
+							<img src={statusPage.logoUrl} alt={statusPage.title} class="w-8 h-8 rounded" />
 						)}
 						<div>
 							<Heading level={1} class="text-2xl font-bold text-primary">{statusPage.title}</Heading>
@@ -96,7 +245,7 @@ const metaDescription = `${statusPage.description} - Current uptime: ${statusPag
 						</div>
 					</div>
 					<div class="flex items-center gap-3">
-						<StatusBadge status={statusPage.status as 'online' | 'offline' | 'degraded' | 'maintenance' | 'unknown'} />
+						<StatusBadge status={overallStatus} />
 					</div>
 				</div>
 			</div>
@@ -105,22 +254,24 @@ const metaDescription = `${statusPage.description} - Current uptime: ${statusPag
 		<main class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
 			<!-- Current Status Banner -->
 			<Section>
-				<Card class={`border-2 ${statusPage.status === 'online' ? 'bg-status-online/10 border-status-online' : 'bg-status-error/10 border-status-error'}`}>
+				<Card class={`border-2 ${overallStatus === 'online' ? 'bg-status-online/10 border-status-online' : overallStatus === 'degraded' ? 'bg-status-warning/10 border-status-warning' : 'bg-status-error/10 border-status-error'}`}>
 					<CardBody>
 						<div class="flex items-center justify-between">
 							<div>
 								<Heading level={2} class="text-xl font-semibold text-primary mb-2">
-									{statusPage.status === 'online' ? 'All Systems Operational' : 'Service Disruption'}
+									{overallStatus === 'online' ? 'All Systems Operational' : overallStatus === 'degraded' ? 'Performance Degradation' : 'Service Disruption'}
 								</Heading>
 								<Paragraph class="text-secondary">
-									{statusPage.status === 'online' 
-										? 'All monitored services are running smoothly' 
-										: 'We are experiencing issues with our services'
+									{overallStatus === 'online' 
+										? 'All monitored services are currently reporting healthy checks.' 
+										: overallStatus === 'degraded'
+                    ? 'At least one service is degraded but still responding.'
+                    : 'One or more monitored services are failing checks.'
 									}
 								</Paragraph>
 							</div>
 							<div class="text-right">
-								<div class="text-3xl font-bold text-primary">{statusPage.uptime}%</div>
+								<div class="text-3xl font-bold text-primary">{Number(statusPage.uptime).toFixed(2)}%</div>
 								<div class="text-sm text-secondary">24h uptime</div>
 							</div>
 						</div>
@@ -132,18 +283,18 @@ const metaDescription = `${statusPage.description} - Current uptime: ${statusPag
 			<Section>
 				<Grid cols="3">
 					<MetricCard 
-						title="Service URL" 
-						value={statusPage.url}
+						title="Service Scope" 
+						value={primaryMetric}
 						icon="GLOBAL"
 					/>
 					<MetricCard 
 						title="Response Time" 
-						value={`${statusPage.avgResponseTime}ms`}
+						value={avgResponseTime > 0 ? `${avgResponseTime}ms` : 'N/A'}
 						icon="PERFORMANCE"
 					/>
 					<MetricCard 
 						title="Monitoring Locations" 
-						value={statusPage.monitoringPeers.toString()}
+						value={monitoringPeers.toString()}
 						icon="PERFORMANCE"
 					/>
 				</Grid>
@@ -156,7 +307,7 @@ const metaDescription = `${statusPage.description} - Current uptime: ${statusPag
 
 			<!-- Global Monitoring Map -->
 			<Section>
-				<GlobalPingMap peerData={peerData} targetUrl={statusPage.url} />
+				<GlobalPingMap peerData={peerData} targetUrl={primaryMetric} />
 			</Section>
 
 			<!-- Recent Incidents -->
@@ -166,40 +317,39 @@ const metaDescription = `${statusPage.description} - Current uptime: ${statusPag
 
 			<!-- Footer -->
 			<Section>
+        <Grid cols="3">
+          {monitorSummaries.map((monitor) => (
+            <Card>
+              <CardBody>
+                <Heading level={3} class="mb-2">{monitor.name}</Heading>
+                <Paragraph class="text-secondary text-sm mb-3">{monitor.url}</Paragraph>
+                <Badge variant={monitor.status === 'online' ? 'success' : monitor.status === 'degraded' ? 'warning' : 'error'}>
+                  {monitor.status}
+                </Badge>
+              </CardBody>
+            </Card>
+          ))}
+        </Grid>
+      </Section>
+
+			<Section>
 				<footer class="border-t border-primary pt-8 mt-12">
 					<div class="text-center text-secondary">
 						<Paragraph class="mb-2">Powered by <strong class="text-primary">Uppe.</strong></Paragraph>
 						<Paragraph class="text-sm">Decentralized P2P uptime monitoring</Paragraph>
 						<div class="mt-4 flex items-center justify-center gap-4 text-xs">
-							<span>Last updated: {new Date(statusPage.lastCheck).toLocaleString()}</span>
+							<span>Last updated: {new Date(lastUpdatedAt).toLocaleString()}</span>
 							<span>•</span>
-							<span>Monitored by {statusPage.monitoringPeers} peers worldwide</span>
+							<span>Monitored by {monitoringPeers} peers worldwide</span>
 						</div>
 					</div>
 				</footer>
 			</Section>
 		</main>
+    </>
+    )}
 	</div>
 </Layout>
-
-<style>
-	/* Custom branding support */
-	:root {
-		--brand-primary: var(--color-accent-primary);
-		--brand-bg: var(--color-surface-primary);
-		--brand-text: var(--color-text-primary);
-	}
-	
-	/* Override theme colors if custom branding is provided */
-	.custom-brand {
-		background-color: var(--brand-bg);
-		color: var(--brand-text);
-	}
-	
-	.custom-brand .accent {
-		color: var(--brand-primary);
-	}
-</style>
 
 <script>
 	// Auto-refresh the page every 30 seconds

--- a/apps/client/src/pages/status-pages-new.astro
+++ b/apps/client/src/pages/status-pages-new.astro
@@ -1,150 +1,35 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import Header from '../components/Header.astro';
-import { 
-  Section, 
-  Grid, 
-  Card, 
-  CardBody, 
-  Heading, 
-  Paragraph, 
-  Button,
-  MetricDisplay,
-  StatusPageCard,
-  Icon
-} from "$ui";
+import StatusPageForm from '../components/StatusPageForm.astro';
+import { monitorClient } from '../lib/api/client';
 
-// Mock data for public status pages
-const statusPages = [
-	{
-		id: '1',
-		title: 'Production API Status',
-		slug: 'production-api',
-		url: 'https://api.example.com',
-		services: ['API Server', 'Database', 'CDN'],
-		uptime: 99.97,
-		visits: 1247,
-		lastIncident: '2024-01-10T08:15:00Z',
-		isActive: true,
-		created: '2024-01-01T00:00:00Z'
-	},
-	{
-		id: '2',
-		title: 'Website Status',
-		slug: 'website-status',
-		url: 'https://example.com',
-		services: ['Web Server', 'Load Balancer'],
-		uptime: 99.85,
-		visits: 856,
-		lastIncident: '2024-01-12T14:23:00Z',
-		isActive: true,
-		created: '2024-01-05T00:00:00Z'
-	},
-	{
-		id: '3',
-		title: 'Internal Tools',
-		slug: 'internal-tools',
-		url: 'https://tools.example.com',
-		services: ['Admin Panel', 'Monitoring Dashboard'],
-		uptime: 98.92,
-		visits: 234,
-		lastIncident: '2024-01-14T16:45:00Z',
-		isActive: false,
-		created: '2024-01-10T00:00:00Z'
-	}
-];
+let monitors: any[] = [];
+try {
+  const response = await monitorClient.listMonitors({ page: 1, pageSize: 100, filter: '' });
+  monitors = response.monitors || [];
+} catch {
+  monitors = [];
+}
 ---
 
-<Layout title="Public Status Pages - Uppe.">
-	<Header />
-	
-	<main class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-		<Section>
-			<div class="flex items-center justify-between mb-4">
-				<div>
-					<Heading level={1} class="mb-2">Public Status Pages</Heading>
-					<Paragraph class="text-secondary">Create and manage public status pages for your services</Paragraph>
-				</div>
-				<Button variant="primary">
-					Create New Page
-				</Button>
-			</div>
-			
-			<!-- Quick Stats -->
-			<Grid cols="4" class="mb-8">
-				<Card>
-					<CardBody>
-						<MetricDisplay 
-							value={statusPages.length}
-							label="Total Pages"
-							color="primary"
-						/>
-					</CardBody>
-				</Card>
-				<Card>
-					<CardBody>
-						<MetricDisplay 
-							value={statusPages.filter(p => p.isActive).length}
-							label="Active Pages"
-							color="success"
-						/>
-					</CardBody>
-				</Card>
-				<Card>
-					<CardBody>
-						<MetricDisplay 
-							value={statusPages.reduce((sum, p) => sum + p.visits, 0).toLocaleString()}
-							label="Total Visits"
-							color="warning"
-						/>
-					</CardBody>
-				</Card>
-				<Card>
-					<CardBody>
-						<MetricDisplay 
-							value={`${(statusPages.reduce((sum, p) => sum + p.uptime, 0) / statusPages.length).toFixed(1)}%`}
-							label="Avg. Uptime"
-							color="primary"
-						/>
-					</CardBody>
-				</Card>
-			</Grid>
-		</Section>
+<Layout title="Create Status Page - Uppe.">
+  <Header />
 
-		<!-- Status Pages List -->
-		<Section>
-			<div class="space-y-4">
-				{statusPages.map((page) => (
-					<StatusPageCard
-						title={page.title}
-						slug={page.slug}
-						isActive={page.isActive}
-						services={page.services}
-						uptime={page.uptime}
-						visits={page.visits}
-						lastIncident={page.lastIncident}
-						created={page.created}
-					/>
-				))}
-			</div>
-		</Section>
+  <main class="min-h-screen bg-bg-primary">
+    <div class="max-w-3xl mx-auto px-6 py-6 space-y-5">
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-xl font-semibold text-primary">Create Status Page</h1>
+          <p class="text-secondary text-sm mt-0.5">Publish a branded status view backed by your monitor data.</p>
+        </div>
+        <a href="/status-pages" class="text-secondary text-sm hover:text-accent-primary transition-colors">← Cancel</a>
+      </div>
 
-		<!-- Create First Page CTA -->
-		<Section>
-			<Card>
-				<CardBody>
-					<div class="text-center py-8">
-						<div class="bg-accent-primary/10 p-4 rounded-full w-16 h-16 mx-auto mb-4 flex items-center justify-center">
-							<Icon icon="DASHBOARD" class="text-accent-primary" />
-						</div>
-						<Heading level={3} class="mb-2">Ready to go public?</Heading>
-						<Paragraph class="text-secondary mb-4">Create your first public status page and keep your users informed about your service status.</Paragraph>
-						<Button variant="primary" size="lg">
-							Create Status Page
-						</Button>
-					</div>
-				</CardBody>
-			</Card>
-		</Section>
-	</main>
+      <StatusPageForm
+        mode="create"
+        monitors={monitors.map((monitor: any) => ({ id: monitor.id, name: monitor.name, url: monitor.url }))}
+      />
+    </div>
+  </main>
 </Layout>

--- a/apps/client/src/pages/status-pages.astro
+++ b/apps/client/src/pages/status-pages.astro
@@ -60,9 +60,15 @@ const avgUptime = statusPages.length > 0
 						<Heading level={1}>Public Status Pages</Heading>
 						<Paragraph color="secondary">Create and manage public status pages for your services</Paragraph>
 					</Stack>
-					<Button variant="primary" disabled={true}>
-						Create New Page Soon
+          {monitors.length > 0 ? (
+					<Button variant="primary" href="/status-pages-new">
+						Create New Page
 					</Button>
+          ) : (
+					<Button variant="primary" disabled={true}>
+						Create New Page
+					</Button>
+          )}
 				</Flex>
 			</Section>
 
@@ -163,9 +169,15 @@ const avgUptime = statusPages.length > 0
 											<span class="px-2 py-1 bg-bg-tertiary rounded text-sm">+{monitors.length - 5} more</span>
 										)}
 									</div>
-									<Button variant="primary" size="lg" class="mt-4" disabled={true}>
-										Create Status Page Soon
+                  {monitors.length > 0 ? (
+									<Button variant="primary" size="lg" class="mt-4" href="/status-pages-new">
+										Create Status Page
 									</Button>
+                  ) : (
+									<Button variant="primary" size="lg" class="mt-4" disabled={true}>
+										Create Status Page
+									</Button>
+                  )}
 								</Stack>
 							) : (
 								<Stack gap="2" align="center">

--- a/apps/client/src/pages/status-pages/[slug]/edit.astro
+++ b/apps/client/src/pages/status-pages/[slug]/edit.astro
@@ -1,0 +1,67 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import Header from '../../../components/Header.astro';
+import StatusPageForm from '../../../components/StatusPageForm.astro';
+import { monitorClient, statusPageClient } from '../../../lib/api/client';
+import { GetStatusPageRequest } from '../../../gen/statuspage/v1/statuspage_pb';
+
+const { slug } = Astro.params;
+if (!slug) return Astro.redirect('/status-pages');
+
+let monitors: any[] = [];
+let statusPage: any = null;
+let fetchError = false;
+
+try {
+  const [monitorResponse, pageResponse] = await Promise.all([
+    monitorClient.listMonitors({ page: 1, pageSize: 100, filter: '' }),
+    statusPageClient.getStatusPage(new GetStatusPageRequest({
+      identifier: { case: 'slug', value: slug },
+    })),
+  ]);
+
+  monitors = monitorResponse.monitors || [];
+  statusPage = pageResponse;
+} catch {
+  fetchError = true;
+}
+---
+
+<Layout title={`Edit ${statusPage?.title ?? 'Status Page'} - Uppe.`}>
+  <Header />
+
+  <main class="min-h-screen bg-bg-primary">
+    <div class="max-w-3xl mx-auto px-6 py-6">
+      {fetchError || !statusPage ? (
+        <div class="rounded-xl border border-primary bg-bg-secondary p-12 text-center space-y-4">
+          <p class="text-primary font-semibold text-lg">Status page not found</p>
+          <a href="/status-pages" class="inline-block text-sm mt-2" style="color: #c4a7e7;">← Back to Status Pages</a>
+        </div>
+      ) : (
+        <div class="space-y-5">
+          <div class="flex items-center justify-between">
+            <div>
+              <h1 class="text-xl font-semibold text-primary">Edit Status Page</h1>
+              <p class="text-secondary text-sm mt-0.5">Update branding, monitors, and publication state.</p>
+            </div>
+            <a href="/status-pages" class="text-secondary text-sm hover:text-accent-primary transition-colors">← Cancel</a>
+          </div>
+
+          <StatusPageForm
+            mode="edit"
+            monitors={monitors.map((monitor: any) => ({ id: monitor.id, name: monitor.name, url: monitor.url }))}
+            page={{
+              id: statusPage.id,
+              title: statusPage.title,
+              slug: statusPage.slug,
+              description: statusPage.description,
+              logoUrl: statusPage.logoUrl,
+              isActive: statusPage.isActive,
+              monitorIds: statusPage.monitorIds,
+            }}
+          />
+        </div>
+      )}
+    </div>
+  </main>
+</Layout>

--- a/apps/server/internal/connect/result/result.go
+++ b/apps/server/internal/connect/result/result.go
@@ -1,0 +1,144 @@
+package result
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"connectrpc.com/connect"
+	"go.uber.org/zap"
+
+	resultv1 "github.com/Obiente/Uppe/apps/server/gen/result/v1"
+	"github.com/Obiente/Uppe/apps/server/gen/result/v1/resultv1connect"
+	"github.com/Obiente/Uppe/apps/server/internal/db"
+	"github.com/Obiente/Uppe/apps/server/internal/db/types"
+)
+
+// ResultService implements the ResultService ConnectRPC service
+type ResultService struct {
+	logger   *zap.Logger
+	database db.Database
+}
+
+// Ensure ResultService implements the interface
+var _ resultv1connect.ResultServiceHandler = (*ResultService)(nil)
+
+func NewResultService(logger *zap.Logger, database db.Database) *ResultService {
+	return &ResultService{
+		logger:   logger,
+		database: database,
+	}
+}
+
+func (s *ResultService) GetResults(
+	ctx context.Context,
+	req *connect.Request[resultv1.GetResultsRequest],
+) (*connect.Response[resultv1.GetResultsResponse], error) {
+	s.logger.Info("GetResults called", zap.String("monitor_id", req.Msg.MonitorId))
+
+	query := &types.ResultQuery{
+		MonitorID: req.Msg.MonitorId,
+		StartTime: time.Unix(req.Msg.StartTime, 0),
+		EndTime:   time.Unix(req.Msg.EndTime, 0),
+		Limit:     int(req.Msg.Limit),
+		Offset:    int(req.Msg.Offset),
+	}
+
+	results, total, err := s.database.GetResults(ctx, query)
+	if err != nil {
+		s.logger.Error("Failed to get results", zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get results: %w", err))
+	}
+
+	protoResults := make([]*resultv1.MonitoringResult, len(results))
+	for i, r := range results {
+		protoResults[i] = r.ToProto()
+	}
+
+	return connect.NewResponse(&resultv1.GetResultsResponse{
+		Results: protoResults,
+		Total:   int32(total),
+	}), nil
+}
+
+func (s *ResultService) GetAggregatedStats(
+	ctx context.Context,
+	req *connect.Request[resultv1.GetAggregatedStatsRequest],
+) (*connect.Response[resultv1.AggregatedStats], error) {
+	s.logger.Info("GetAggregatedStats called", zap.String("monitor_id", req.Msg.MonitorId))
+
+	var period types.AggregationPeriod
+	switch req.Msg.Period {
+	case resultv1.AggregationPeriod_AGGREGATION_PERIOD_HOUR:
+		period = types.AggregationPeriodHour
+	case resultv1.AggregationPeriod_AGGREGATION_PERIOD_DAY:
+		period = types.AggregationPeriodDay
+	case resultv1.AggregationPeriod_AGGREGATION_PERIOD_WEEK:
+		period = types.AggregationPeriodWeek
+	case resultv1.AggregationPeriod_AGGREGATION_PERIOD_MONTH:
+		period = types.AggregationPeriodMonth
+	default:
+		period = types.AggregationPeriodDay
+	}
+
+	points, err := s.database.GetAggregatedStats(ctx,
+		req.Msg.MonitorId,
+		time.Unix(req.Msg.StartTime, 0),
+		time.Unix(req.Msg.EndTime, 0),
+		period,
+	)
+	if err != nil {
+		s.logger.Error("Failed to get aggregated stats", zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get aggregated stats: %w", err))
+	}
+
+	protoPoints := make([]*resultv1.TimeSeriesDataPoint, len(points))
+	for i, p := range points {
+		protoPoints[i] = p.ToProto()
+	}
+
+	return connect.NewResponse(&resultv1.AggregatedStats{
+		DataPoints: protoPoints,
+	}), nil
+}
+
+func (s *ResultService) StreamResults(
+	ctx context.Context,
+	req *connect.Request[resultv1.StreamResultsRequest],
+	stream *connect.ServerStream[resultv1.MonitoringResult],
+) error {
+	s.logger.Info("StreamResults called", zap.String("monitor_id", req.Msg.MonitorId))
+
+	// TODO: Implement result streaming
+	return nil
+}
+
+func (s *ResultService) GetGlobalPing(
+	ctx context.Context,
+	req *connect.Request[resultv1.GetGlobalPingRequest],
+) (*connect.Response[resultv1.GetGlobalPingResponse], error) {
+	s.logger.Info("GetGlobalPing called", zap.String("monitor_id", req.Msg.MonitorId))
+
+	samples, err := s.database.GetGlobalPingSamples(ctx,
+		req.Msg.MonitorId,
+		time.Unix(req.Msg.StartTime, 0),
+		time.Unix(req.Msg.EndTime, 0),
+	)
+	if err != nil {
+		s.logger.Error("Failed to get global ping samples", zap.Error(err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get global ping samples: %w", err))
+	}
+
+	protoSamples := make([]*resultv1.GlobalPingSample, len(samples))
+	for i, r := range samples {
+		protoSamples[i] = &resultv1.GlobalPingSample{
+			PeerId:    r.MonitorNodeID,
+			Location:  r.Location,
+			LatencyMs: int32(r.LatencyMs),
+			Status:    r.Status,
+			Timestamp: r.Timestamp.Unix(),
+		}
+	}
+
+	return connect.NewResponse(&resultv1.GetGlobalPingResponse{Samples: protoSamples}), nil
+}


### PR DESCRIPTION
## Summary
- replace the mock public status page route with live API-backed data
- add real create and edit status page flows in Astro
- wire list-page actions back on and route card edits to the new edit page
- include global ping locations in result service responses for the public page

## Testing
- go test ./...
- frontend build not run in this shell because node is unavailable

Closes #34