### PR TITLE
feat(service): add signed audit event foundation

### DIFF
--- a/BACKEND_FIRST_IMPLEMENTATION_PLAN.md
+++ b/BACKEND_FIRST_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,238 @@
+# Backend-First Implementation Plan
+
+This document defines the next implementation order for Uppe after the current
+API/frontend stabilization work. The goal is to stop building outward from UI
+assumptions and instead build upward from a stable backend domain model.
+
+## Core Rule
+
+Implementation order is:
+
+1. Rust domain/runtime
+2. Rust-owned schema and signed event model
+3. Go API/read models
+4. Astro frontend
+
+No new frontend feature should be added unless the Rust runtime and the API
+contract already support it.
+
+## Ownership
+
+Rust owns:
+
+- monitor execution
+- P2P protocols and replication
+- trust and signature verification
+- audit/event emission
+- canonical writes to the shared database
+- status-page publish/revision generation
+
+Go owns:
+
+- query APIs
+- CRUD APIs for operator workflows
+- read models and projections derived from Rust-owned state
+- public read endpoints for dashboards and status pages
+
+Astro owns:
+
+- operator UX
+- public status page UX
+- rendering and interaction only
+
+## Immediate Program
+
+### Milestone 1: Canonical Signed Event Envelope
+
+Deliverables:
+
+- one canonical event envelope for trust-sensitive actions
+- deterministic serialization rules
+- event signing and verification helpers
+- append-only event storage in Rust
+
+Events that must use the envelope:
+
+- monitor created
+- monitor updated
+- monitor deleted
+- monitor result recorded
+- peer result replicated
+- peer attestation recorded
+- status page published
+- status page revised
+- trust-chain updated
+- capability granted or revoked
+
+Exit criteria:
+
+- no trust-sensitive mutation is represented only as mutable row state
+- all new trust-sensitive writes can emit an event envelope
+
+### Milestone 2: Trust Hardening
+
+Deliverables:
+
+- remove placeholder signature-verification paths
+- define attestation semantics clearly
+- define verification quorum semantics
+- split trust validation from orchestration and UI concerns
+
+Implementation focus:
+
+- `apps/service/src/orchestrator/admin_trust.rs`
+- `crates/peerup/src/trust`
+- any message verification path that currently accepts unverifiable data
+
+Exit criteria:
+
+- no production trust path succeeds via placeholder checks
+- invalid signatures fail closed
+- trust decisions become inspectable from signed data
+
+### Milestone 3: Public Status Page Backend Model
+
+The public page should stop deriving rich UI state from a CRUD message.
+
+Deliverables:
+
+- dedicated backend read model for public status pages
+- status page revision/publish model in Rust
+- monitor summaries for public pages
+- recent incident summaries
+- uptime history and global ping samples
+
+Recommended model split:
+
+- `status_pages`:
+  operator-owned page identity and config
+- `status_page_revisions`:
+  immutable published page bundles or metadata pointers
+- `status_page_monitors`:
+  monitor inclusion and ordering
+- `status_page_read_models`:
+  query-optimized public projection
+
+Exit criteria:
+
+- public page routes consume a public read model, not CRUD state plus guesses
+- status page data can be replicated later without redesigning the model
+
+### Milestone 4: Runtime Separation
+
+Rust should be split by runtime responsibility, not by mixed orchestration files.
+
+Target shape:
+
+- `runtime/monitoring`
+- `runtime/p2p`
+- `runtime/trust`
+- `runtime/status_pages`
+- `domain/monitors`
+- `domain/results`
+- `domain/audit`
+- `domain/status_pages`
+
+Rules:
+
+- monitoring execution must not own trust policy
+- trust runtime must not own UI-facing read models
+- P2P transport must not be mixed into monitor scheduling code
+
+Exit criteria:
+
+- module boundaries match domain responsibilities
+- transport, monitoring, and trust can evolve independently
+
+### Milestone 5: Decentralized Authentication Foundation
+
+Authentication must be built as an extension of trust and identity, not as a
+centralized web login bolted on later.
+
+Deliverables:
+
+- node identity model
+- challenge-response auth design
+- signed capability grants
+- key rotation model
+- operator auth strategy for UI/API access
+
+Detailed spec is in
+[DECENTRALIZED_AUTH_AND_SIGNED_EVENTS.md](/home/crunchy/dev/Obiente/Uppe/DECENTRALIZED_AUTH_AND_SIGNED_EVENTS.md).
+
+Exit criteria:
+
+- operator auth and peer auth share the same cryptographic foundations
+- capabilities are delegable without central session state
+
+## Data Flow Rules
+
+### Monitoring
+
+1. Rust executes checks.
+2. Rust writes canonical result rows.
+3. Rust emits signed result events.
+4. Rust replicates result events and/or derived records to peers.
+5. Go exposes read/query APIs over canonical and projected state.
+6. Astro renders from Go contracts only.
+
+### Status Pages
+
+1. Operator configures page through API.
+2. Rust creates or updates publishable page state.
+3. Rust emits signed publish/revision events.
+4. Go exposes operator CRUD and public read models.
+5. Astro renders the operator page and public page from those read models.
+
+### Trust and Audit
+
+1. Rust receives or creates signed events.
+2. Rust verifies signatures and policy.
+3. Rust stores event envelopes and attestations.
+4. Go exposes query APIs for audits, trust state, and verification summaries.
+5. Astro renders trust/audit views from those APIs.
+
+## Rules For New Work
+
+Before adding any feature:
+
+1. Is the Rust domain model defined?
+2. Is the schema owned by Rust migrations?
+3. Is there a signed event if the action is trust-sensitive?
+4. Is the API contract generated from a canonical source?
+5. Is the frontend only consuming backend-supported data?
+
+If any answer is no, the feature is not ready for frontend-first work.
+
+## Next Tickets To Execute
+
+Recommended next sequence:
+
+1. Define `SignedEventEnvelope` in Rust.
+2. Add canonical serialization and signature helpers.
+3. Add audit event persistence tables.
+4. Refactor placeholder trust verification out of production paths.
+5. Define `PublicStatusPageView` API contract.
+6. Implement Rust-side status page revision generation.
+7. Expose Go read model endpoints for public status pages.
+8. Only then expand frontend status-page UX further.
+
+## What To Avoid
+
+Do not:
+
+- add new frontend pages that fabricate missing backend state
+- hand-maintain parallel models across Rust, Go, and Astro
+- treat trust verification as a UI concern
+- treat decentralized auth as a later unrelated subsystem
+- keep extending CRUD `StatusPage` to behave like a public page read model
+
+## Definition Of Success
+
+The backend-first direction is working when:
+
+- Rust is the clear execution and trust authority
+- Go is a thin, reliable query and operator API layer
+- Astro no longer needs mock-derived business logic
+- public pages, audits, and auth all sit on the same identity and event model
+

--- a/DECENTRALIZED_AUTH_AND_SIGNED_EVENTS.md
+++ b/DECENTRALIZED_AUTH_AND_SIGNED_EVENTS.md
@@ -1,0 +1,311 @@
+# Decentralized Authentication And Signed Events
+
+This document defines the intended trust model for Uppe:
+
+- identity is cryptographic
+- trust-sensitive actions become signed events
+- authentication is challenge-response, not password/session centric
+- authorization is capability-based
+
+## Goals
+
+Uppe needs:
+
+- stable node identity
+- decentralized peer authentication
+- operator authentication without a central auth server
+- auditable authorization changes
+- signed publish and verification flows for status pages and monitoring
+
+## Non-Goals
+
+This design does not require:
+
+- a centralized identity provider
+- long-lived bearer sessions as the core trust primitive
+- browser-native peer transport for website hosting
+
+## Identity Model
+
+### Node Identity
+
+Each node has a long-lived Ed25519 keypair.
+
+The public key is the root identity.
+The node ID is a stable derivation of that public key.
+
+The same root identity should anchor:
+
+- signed event envelopes
+- peer authentication
+- capability delegation
+- status-page publish ownership
+
+### Operator Identity
+
+There are two operator modes:
+
+1. Local operator
+2. Delegated operator
+
+Local operator:
+
+- authenticates directly to their node
+- proves control via challenge-response signature or local secure mechanism
+
+Delegated operator:
+
+- receives a signed capability grant from the node owner or admin authority
+- can act only within the granted scope
+
+### Optional Human-Friendly Layer
+
+Later, WebAuthn can be added as a human-friendly operator login mechanism.
+That should be a wrapper around cryptographic identity, not a replacement for it.
+
+## Authentication Model
+
+### Peer Authentication
+
+Peer-to-peer authentication uses:
+
+- transport-level authenticated channels where available
+- signed application-layer messages always
+
+Rules:
+
+- transport authentication alone is not sufficient for trust-sensitive state
+- trust-sensitive messages must carry signed payloads
+- receivers verify signature, key identity, and policy scope
+
+### Operator Authentication
+
+Operator login should use challenge-response:
+
+1. Client requests nonce/challenge.
+2. Node returns a short-lived challenge with expiration and audience.
+3. Operator signs the challenge using the authorized key.
+4. Node verifies the signature and issues a short-lived capability-bound session
+   token or signed access token.
+
+Short-lived tokens may exist for convenience, but they are derived from signed
+proof and should remain revocable and scope-limited.
+
+## Authorization Model
+
+Authorization should be capability-based.
+
+Examples of capabilities:
+
+- `monitors:create`
+- `monitors:update`
+- `monitors:delete`
+- `status_pages:create`
+- `status_pages:update`
+- `status_pages:publish`
+- `peers:approve`
+- `trust:rotate_keys`
+- `audit:read`
+
+Each capability grant should be:
+
+- signed
+- scoped
+- time-bounded when possible
+- revocable via later signed event
+
+## Signed Event Envelope
+
+Every trust-sensitive action should become a signed event.
+
+## Envelope Shape
+
+Recommended logical fields:
+
+- `event_id`
+- `event_type`
+- `schema_version`
+- `created_at`
+- `actor_id`
+- `actor_public_key`
+- `resource_type`
+- `resource_id`
+- `parent_event_id` or `previous_event_hash`
+- `payload`
+- `payload_hash`
+- `signature`
+
+Optional:
+
+- `capability_id`
+- `delegated_by`
+- `expires_at`
+- `context`
+
+## Envelope Rules
+
+Rules:
+
+- payload serialization must be canonical
+- signature is over canonical bytes, not ad hoc JSON rendering
+- payloads are immutable once signed
+- later changes produce new events, not in-place mutation
+- verification results are separate attestations, not edits to the source event
+
+## Event Categories
+
+At minimum:
+
+- monitor lifecycle events
+- monitor result events
+- peer replication events
+- peer attestation events
+- status page publish/revision events
+- capability grant/revoke events
+- trust-chain rotation events
+- admin policy change events
+
+## Attestations
+
+Attestations are separate signed events that refer to another event.
+
+Examples:
+
+- peer verified result
+- peer rejected signature
+- peer confirmed status page revision hash
+- admin approved capability grant
+
+Recommended fields:
+
+- `attestation_id`
+- `subject_event_id`
+- `attestor_id`
+- `decision`
+- `reason`
+- `signature`
+- `created_at`
+
+## Storage Model
+
+Recommended tables:
+
+- `audit_events`
+- `audit_attestations`
+- `capability_grants`
+- `capability_revocations`
+- `identity_keys`
+- `identity_rotations`
+
+Important property:
+
+mutable read models can exist, but the event store is the canonical history.
+
+## Key Rotation
+
+Key rotation must be auditable.
+
+Recommended model:
+
+1. Current key signs a rotation event naming the next key.
+2. Next key countersigns or becomes valid at a declared point.
+3. Peers verify the chain.
+4. Revocation status is represented explicitly by later signed events.
+
+This gives:
+
+- inspectable trust lineage
+- recovery without hidden state
+- compatibility with distributed verification
+
+## Status Pages In This Model
+
+Status pages should also fit the same trust system.
+
+Owner signs:
+
+- page creation
+- page revisions
+- publish pointers
+- domain bindings when supported
+
+Peers can attest:
+
+- revision availability
+- revision hash validity
+- observed monitor summary agreement
+
+This makes public pages:
+
+- attributable
+- verifiable
+- replicable
+
+## Recommended Token Model
+
+If API tokens are needed, they should be:
+
+- short-lived
+- signed
+- audience-bound
+- capability-bound
+
+Prefer:
+
+- signed access token derived from challenge-response
+
+Avoid:
+
+- broad permanent bearer tokens without audit linkage
+
+## Backend Implementation Order
+
+1. Define canonical event envelope types in Rust.
+2. Define canonical serialization rules.
+3. Implement signing and verification helpers.
+4. Persist events and attestations.
+5. Make trust-sensitive backend actions emit events.
+6. Add capability grants and revocations.
+7. Add operator challenge-response auth.
+8. Add Go APIs that surface read models of identities, grants, and audits.
+9. Add Astro flows on top of those APIs.
+
+## API Design Implications
+
+The Go API should eventually expose:
+
+- `AuthService`
+- `CapabilityService`
+- `AuditService`
+- `PublicStatusPageService` or equivalent public read service
+
+These should query Rust-owned state, not invent their own authority.
+
+## Security Constraints
+
+Hard requirements:
+
+- invalid signatures fail closed
+- expired challenges are rejected
+- capability scope is checked on every write path
+- key rotation is chain-validated
+- all trust-sensitive changes are auditable
+
+## Practical First Version
+
+Version 1 can be simpler:
+
+- one node root keypair
+- challenge-response operator auth
+- signed event envelope for monitor/status-page/trust changes
+- signed capability grants for operator roles
+- peer attestations for replicated results
+
+That is enough to build:
+
+- decentralized operator auth
+- inspectable trust history
+- verifiable peer coordination
+
+without waiting for a fully federated identity ecosystem.
+

--- a/apps/service/src/audit/mod.rs
+++ b/apps/service/src/audit/mod.rs
@@ -1,14 +1,18 @@
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use ed25519_dalek::{Signature, Signer, Verifier, VerifyingKey};
 use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use crate::crypto::KeyPair;
+use crate::crypto::{KeyPair, load_or_generate_keypair};
+use crate::database::Database;
+use crate::database::models::{AuditAttestation, AuditEvent, Monitor, PeerResult};
+use crate::monitoring::types::CheckResult;
 
 #[derive(Debug, Clone, Serialize)]
 struct SignableEventEnvelope<'a> {
@@ -27,6 +31,17 @@ struct SignableEventEnvelope<'a> {
     delegated_by: Option<&'a str>,
     expires_at: Option<i64>,
     context_json: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SignableAttestationEnvelope<'a> {
+    attestation_id: &'a str,
+    subject_event_id: &'a str,
+    attestor_id: &'a str,
+    attestor_public_key_hex: String,
+    decision: &'a str,
+    reason: Option<&'a str>,
+    created_at: i64,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -61,6 +76,44 @@ pub struct NewSignedEvent<'a, T: Serialize, C: Serialize> {
     pub delegated_by: Option<&'a str>,
     pub expires_at: Option<SystemTime>,
     pub context: Option<&'a C>,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditDecision {
+    Accepted,
+    Rejected,
+    Observed,
+}
+
+impl AuditDecision {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Accepted => "accepted",
+            Self::Rejected => "rejected",
+            Self::Observed => "observed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SignedAuditAttestation {
+    pub attestation_id: Uuid,
+    pub subject_event_id: Uuid,
+    pub attestor_id: String,
+    pub attestor_public_key: Vec<u8>,
+    pub decision: AuditDecision,
+    pub reason: Option<String>,
+    pub created_at: SystemTime,
+    pub signature: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewAuditAttestation<'a> {
+    pub subject_event_id: Uuid,
+    pub attestor_id: &'a str,
+    pub decision: AuditDecision,
+    pub reason: Option<&'a str>,
 }
 
 impl SignedEventEnvelope {
@@ -158,8 +211,357 @@ impl SignedEventEnvelope {
     }
 }
 
+impl SignedAuditAttestation {
+    pub fn sign(spec: NewAuditAttestation<'_>, keypair: &KeyPair) -> Result<Self> {
+        let mut attestation = Self {
+            attestation_id: Uuid::new_v4(),
+            subject_event_id: spec.subject_event_id,
+            attestor_id: spec.attestor_id.to_string(),
+            attestor_public_key: keypair.public_key_bytes().to_vec(),
+            decision: spec.decision,
+            reason: spec.reason.map(ToOwned::to_owned),
+            created_at: SystemTime::now(),
+            signature: Vec::new(),
+        };
+
+        let signature = keypair.signing_key.sign(&attestation.signing_bytes()?);
+        attestation.signature = signature.to_bytes().to_vec();
+        Ok(attestation)
+    }
+
+    pub fn verify(&self) -> Result<bool> {
+        let public_key_bytes: [u8; 32] = self
+            .attestor_public_key
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow!("invalid attestor public key length"))?;
+        let signature_bytes: [u8; 64] = self
+            .signature
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow!("invalid attestation signature length"))?;
+
+        let verifying_key = VerifyingKey::from_bytes(&public_key_bytes)
+            .map_err(|e| anyhow!("invalid attestor public key: {e}"))?;
+        let signature = Signature::from_bytes(&signature_bytes);
+        Ok(verifying_key.verify(&self.signing_bytes()?, &signature).is_ok())
+    }
+
+    pub fn to_model(&self) -> AuditAttestation {
+        AuditAttestation {
+            id: None,
+            attestation_uuid: self.attestation_id,
+            subject_event_uuid: self.subject_event_id,
+            attestor_id: self.attestor_id.clone(),
+            attestor_public_key: self.attestor_public_key.clone(),
+            decision: self.decision.as_str().to_string(),
+            reason: self.reason.clone(),
+            created_at: self.created_at,
+            signature: self.signature.clone(),
+        }
+    }
+
+    fn signing_bytes(&self) -> Result<Vec<u8>> {
+        Ok(serde_json::to_vec(&SignableAttestationEnvelope {
+            attestation_id: &self.attestation_id.to_string(),
+            subject_event_id: &self.subject_event_id.to_string(),
+            attestor_id: &self.attestor_id,
+            attestor_public_key_hex: hex::encode(&self.attestor_public_key),
+            decision: self.decision.as_str(),
+            reason: self.reason.as_deref(),
+            created_at: system_time_to_i64(self.created_at),
+        })?)
+    }
+}
+
 pub fn canonical_json_string(value: &Value) -> Result<String> {
     Ok(serde_json::to_string(&canonicalize_value(value))?)
+}
+
+#[derive(Debug, Serialize)]
+struct MonitorAuditPayload<'a> {
+    action: &'a str,
+    monitor_uuid: Uuid,
+    name: &'a str,
+    target: &'a str,
+    check_type: &'a str,
+    interval_seconds: u64,
+    timeout_seconds: u64,
+    enabled: bool,
+    visibility: &'a crate::database::models::MonitorVisibility,
+    public_domain: Option<&'a str>,
+    public_display_name: Option<&'a str>,
+    owner_peer_id: Option<&'a str>,
+}
+
+#[derive(Debug, Serialize)]
+struct ResultAuditPayload<'a> {
+    source: &'a str,
+    monitor_uuid: Uuid,
+    target: &'a str,
+    check_type: &'a str,
+    status: &'a crate::monitoring::types::MonitorStatus,
+    latency_ms: Option<u64>,
+    status_code: Option<u16>,
+    error_message: Option<&'a str>,
+    peer_id: &'a str,
+    timestamp: i64,
+    verified: Option<bool>,
+    source_peer_id: Option<&'a str>,
+    synced_from_peer: Option<bool>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize)]
+struct AdminTrustAuditPayload<'a> {
+    action: &'a str,
+    source: &'a str,
+    version: u64,
+    previous_version: Option<u64>,
+    key_count: usize,
+    rotation_count: usize,
+    revoked_key_count: usize,
+}
+
+pub fn load_local_keypair() -> Result<KeyPair> {
+    let keypair_path =
+        std::env::var("UPPE_KEYPAIR_PATH").unwrap_or_else(|_| "uppe_keypair.key".to_string());
+    let keypair_path = PathBuf::from(keypair_path);
+    load_or_generate_keypair(&keypair_path)
+        .with_context(|| format!("failed to load local audit keypair from {:?}", keypair_path))
+}
+
+pub async fn record_monitor_event(
+    database: &dyn Database,
+    keypair: &KeyPair,
+    actor_id: &str,
+    action: &str,
+    monitor: &Monitor,
+) -> Result<Uuid> {
+    let event_type = match action {
+        "created" => "monitor.created",
+        "updated" => "monitor.updated",
+        "deleted" => "monitor.deleted",
+        _ => "monitor.updated",
+    };
+    let resource_id = monitor.uuid.to_string();
+
+    let payload = MonitorAuditPayload {
+        action,
+        monitor_uuid: monitor.uuid,
+        name: &monitor.name,
+        target: &monitor.target,
+        check_type: &monitor.check_type,
+        interval_seconds: monitor.interval_seconds,
+        timeout_seconds: monitor.timeout_seconds,
+        enabled: monitor.enabled,
+        visibility: &monitor.visibility,
+        public_domain: monitor.public_domain.as_deref(),
+        public_display_name: monitor.public_display_name.as_deref(),
+        owner_peer_id: monitor.owner_peer_id.as_deref(),
+    };
+
+    save_signed_event(
+        database,
+        keypair,
+        NewSignedEvent::<_, Value> {
+            event_type,
+            actor_id,
+            resource_type: "monitor",
+            resource_id: &resource_id,
+            parent_event_id: None,
+            payload: &payload,
+            capability_id: None,
+            delegated_by: None,
+            expires_at: None,
+            context: None,
+        },
+    )
+    .await
+}
+
+pub async fn record_local_result_event(
+    database: &dyn Database,
+    keypair: &KeyPair,
+    actor_id: &str,
+    source: &str,
+    result: &CheckResult,
+) -> Result<Uuid> {
+    let resource_id = result.monitor_id.to_string();
+    let payload = ResultAuditPayload {
+        source,
+        monitor_uuid: result.monitor_id,
+        target: &result.target,
+        check_type: &result.check_type,
+        status: &result.status,
+        latency_ms: result.latency_ms,
+        status_code: result.status_code,
+        error_message: result.error_message.as_deref(),
+        peer_id: &result.peer_id,
+        timestamp: system_time_to_i64(result.timestamp),
+        verified: None,
+        source_peer_id: None,
+        synced_from_peer: None,
+    };
+
+    save_signed_event(
+        database,
+        keypair,
+        NewSignedEvent::<_, Value> {
+            event_type: "monitor.result_recorded",
+            actor_id,
+            resource_type: "monitor",
+            resource_id: &resource_id,
+            parent_event_id: None,
+            payload: &payload,
+            capability_id: None,
+            delegated_by: None,
+            expires_at: None,
+            context: None,
+        },
+    )
+    .await
+}
+
+pub async fn record_peer_result_event(
+    database: &dyn Database,
+    keypair: &KeyPair,
+    actor_id: &str,
+    source: &str,
+    result: &PeerResult,
+) -> Result<Uuid> {
+    let resource_id = result.monitor_uuid.to_string();
+    let payload = ResultAuditPayload {
+        source,
+        monitor_uuid: result.monitor_uuid,
+        target: "",
+        check_type: "",
+        status: &result.status,
+        latency_ms: result.latency_ms,
+        status_code: result.status_code,
+        error_message: result.error_message.as_deref(),
+        peer_id: &result.peer_id,
+        timestamp: system_time_to_i64(result.timestamp),
+        verified: Some(result.verified),
+        source_peer_id: result.source_peer_id.as_deref(),
+        synced_from_peer: Some(result.synced_from_peer),
+    };
+
+    save_signed_event(
+        database,
+        keypair,
+        NewSignedEvent::<_, Value> {
+            event_type: "peer.result_recorded",
+            actor_id,
+            resource_type: "monitor",
+            resource_id: &resource_id,
+            parent_event_id: None,
+            payload: &payload,
+            capability_id: None,
+            delegated_by: None,
+            expires_at: None,
+            context: None,
+        },
+    )
+    .await
+}
+
+pub async fn record_result_verification_attestation(
+    database: &dyn Database,
+    keypair: &KeyPair,
+    actor_id: &str,
+    subject_event_id: Uuid,
+    verified: bool,
+    reason: Option<&str>,
+) -> Result<Uuid> {
+    let attestation = SignedAuditAttestation::sign(
+        NewAuditAttestation {
+            subject_event_id,
+            attestor_id: actor_id,
+            decision: if verified { AuditDecision::Accepted } else { AuditDecision::Rejected },
+            reason,
+        },
+        keypair,
+    )?;
+    let attestation_id = attestation.attestation_id;
+    database.save_audit_attestation(&attestation.to_model()).await?;
+    Ok(attestation_id)
+}
+
+#[allow(dead_code)]
+pub async fn record_admin_trust_event(
+    database: &dyn Database,
+    keypair: &KeyPair,
+    actor_id: &str,
+    action: &str,
+    source: &str,
+    version: u64,
+    previous_version: Option<u64>,
+    key_count: usize,
+    rotation_count: usize,
+    revoked_key_count: usize,
+) -> Result<Uuid> {
+    let payload = AdminTrustAuditPayload {
+        action,
+        source,
+        version,
+        previous_version,
+        key_count,
+        rotation_count,
+        revoked_key_count,
+    };
+
+    save_signed_event(
+        database,
+        keypair,
+        NewSignedEvent::<_, Value> {
+            event_type: "admin_trust.chain_updated",
+            actor_id,
+            resource_type: "admin_trust_chain",
+            resource_id: "global",
+            parent_event_id: None,
+            payload: &payload,
+            capability_id: None,
+            delegated_by: None,
+            expires_at: None,
+            context: None,
+        },
+    )
+    .await
+}
+
+async fn save_signed_event<T: Serialize, C: Serialize>(
+    database: &dyn Database,
+    keypair: &KeyPair,
+    spec: NewSignedEvent<'_, T, C>,
+) -> Result<Uuid> {
+    let envelope = SignedEventEnvelope::sign(spec, keypair)?;
+    let event_uuid = envelope.event_id;
+    let event = envelope_to_model(envelope);
+    database.save_audit_event(&event).await?;
+    Ok(event_uuid)
+}
+
+fn envelope_to_model(envelope: SignedEventEnvelope) -> AuditEvent {
+    AuditEvent {
+        id: None,
+        event_uuid: envelope.event_id,
+        event_type: envelope.event_type,
+        schema_version: envelope.schema_version,
+        created_at: envelope.created_at,
+        actor_id: envelope.actor_id,
+        actor_public_key: envelope.actor_public_key,
+        resource_type: envelope.resource_type,
+        resource_id: envelope.resource_id,
+        parent_event_uuid: envelope.parent_event_id,
+        payload_json: envelope.payload_json,
+        payload_hash: envelope.payload_hash,
+        capability_id: envelope.capability_id,
+        delegated_by: envelope.delegated_by,
+        expires_at: envelope.expires_at,
+        context_json: envelope.context_json,
+        signature: envelope.signature,
+    }
 }
 
 fn canonicalize_value(value: &Value) -> Value {
@@ -223,5 +625,22 @@ mod tests {
         .unwrap();
 
         assert!(event.verify().unwrap());
+    }
+
+    #[test]
+    fn signed_attestation_round_trips_verification() {
+        let keypair = generate_keypair();
+        let attestation = SignedAuditAttestation::sign(
+            NewAuditAttestation {
+                subject_event_id: Uuid::new_v4(),
+                attestor_id: "peer-1",
+                decision: AuditDecision::Accepted,
+                reason: Some("signature valid"),
+            },
+            &keypair,
+        )
+        .unwrap();
+
+        assert!(attestation.verify().unwrap());
     }
 }

--- a/apps/service/src/audit/mod.rs
+++ b/apps/service/src/audit/mod.rs
@@ -1,0 +1,227 @@
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Result, anyhow};
+use ed25519_dalek::{Signature, Signer, Verifier, VerifyingKey};
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::crypto::KeyPair;
+
+#[derive(Debug, Clone, Serialize)]
+struct SignableEventEnvelope<'a> {
+    event_id: &'a str,
+    event_type: &'a str,
+    schema_version: i32,
+    created_at: i64,
+    actor_id: &'a str,
+    actor_public_key_hex: String,
+    resource_type: &'a str,
+    resource_id: &'a str,
+    parent_event_id: Option<String>,
+    payload_json: &'a str,
+    payload_hash: &'a str,
+    capability_id: Option<&'a str>,
+    delegated_by: Option<&'a str>,
+    expires_at: Option<i64>,
+    context_json: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SignedEventEnvelope {
+    pub event_id: Uuid,
+    pub event_type: String,
+    pub schema_version: i32,
+    pub created_at: SystemTime,
+    pub actor_id: String,
+    pub actor_public_key: Vec<u8>,
+    pub resource_type: String,
+    pub resource_id: String,
+    pub parent_event_id: Option<Uuid>,
+    pub payload_json: String,
+    pub payload_hash: String,
+    pub capability_id: Option<String>,
+    pub delegated_by: Option<String>,
+    pub expires_at: Option<SystemTime>,
+    pub context_json: Option<String>,
+    pub signature: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewSignedEvent<'a, T: Serialize, C: Serialize> {
+    pub event_type: &'a str,
+    pub actor_id: &'a str,
+    pub resource_type: &'a str,
+    pub resource_id: &'a str,
+    pub parent_event_id: Option<Uuid>,
+    pub payload: &'a T,
+    pub capability_id: Option<&'a str>,
+    pub delegated_by: Option<&'a str>,
+    pub expires_at: Option<SystemTime>,
+    pub context: Option<&'a C>,
+}
+
+impl SignedEventEnvelope {
+    pub const SCHEMA_VERSION: i32 = 1;
+
+    pub fn sign<T: Serialize, C: Serialize>(
+        spec: NewSignedEvent<'_, T, C>,
+        keypair: &KeyPair,
+    ) -> Result<Self> {
+        let payload_json = canonical_json_string(&serde_json::to_value(spec.payload)?)?;
+        let payload_hash = hex::encode(Sha256::digest(payload_json.as_bytes()));
+        let context_json = match spec.context {
+            Some(context) => Some(canonical_json_string(&serde_json::to_value(context)?)?),
+            None => None,
+        };
+
+        let mut event = Self {
+            event_id: Uuid::new_v4(),
+            event_type: spec.event_type.to_string(),
+            schema_version: Self::SCHEMA_VERSION,
+            created_at: SystemTime::now(),
+            actor_id: spec.actor_id.to_string(),
+            actor_public_key: keypair.public_key_bytes().to_vec(),
+            resource_type: spec.resource_type.to_string(),
+            resource_id: spec.resource_id.to_string(),
+            parent_event_id: spec.parent_event_id,
+            payload_json,
+            payload_hash,
+            capability_id: spec.capability_id.map(ToOwned::to_owned),
+            delegated_by: spec.delegated_by.map(ToOwned::to_owned),
+            expires_at: spec.expires_at,
+            context_json,
+            signature: Vec::new(),
+        };
+
+        let signature = keypair.signing_key.sign(&event.signing_bytes()?);
+        event.signature = signature.to_bytes().to_vec();
+        Ok(event)
+    }
+
+    pub fn verify(&self) -> Result<bool> {
+        let public_key_bytes: [u8; 32] = self
+            .actor_public_key
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow!("invalid actor public key length"))?;
+        let signature_bytes: [u8; 64] = self
+            .signature
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow!("invalid signature length"))?;
+
+        let expected_hash = hex::encode(Sha256::digest(self.payload_json.as_bytes()));
+        if expected_hash != self.payload_hash {
+            return Ok(false);
+        }
+
+        let verifying_key = VerifyingKey::from_bytes(&public_key_bytes)
+            .map_err(|e| anyhow!("invalid actor public key: {e}"))?;
+        let signature = Signature::from_bytes(&signature_bytes);
+        Ok(verifying_key.verify(&self.signing_bytes()?, &signature).is_ok())
+    }
+
+    #[allow(dead_code)]
+    pub fn payload_value(&self) -> Result<Value> {
+        Ok(serde_json::from_str(&self.payload_json)?)
+    }
+
+    #[allow(dead_code)]
+    pub fn context_value(&self) -> Result<Option<Value>> {
+        self.context_json
+            .as_ref()
+            .map(|json| serde_json::from_str(json).map_err(Into::into))
+            .transpose()
+    }
+
+    fn signing_bytes(&self) -> Result<Vec<u8>> {
+        Ok(serde_json::to_vec(&SignableEventEnvelope {
+            event_id: &self.event_id.to_string(),
+            event_type: &self.event_type,
+            schema_version: self.schema_version,
+            created_at: system_time_to_i64(self.created_at),
+            actor_id: &self.actor_id,
+            actor_public_key_hex: hex::encode(&self.actor_public_key),
+            resource_type: &self.resource_type,
+            resource_id: &self.resource_id,
+            parent_event_id: self.parent_event_id.map(|id| id.to_string()),
+            payload_json: &self.payload_json,
+            payload_hash: &self.payload_hash,
+            capability_id: self.capability_id.as_deref(),
+            delegated_by: self.delegated_by.as_deref(),
+            expires_at: self.expires_at.map(system_time_to_i64),
+            context_json: self.context_json.as_deref(),
+        })?)
+    }
+}
+
+pub fn canonical_json_string(value: &Value) -> Result<String> {
+    Ok(serde_json::to_string(&canonicalize_value(value))?)
+}
+
+fn canonicalize_value(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut ordered = BTreeMap::new();
+            for (key, value) in map {
+                ordered.insert(key.clone(), canonicalize_value(value));
+            }
+            serde_json::to_value(ordered).expect("ordered map should serialize")
+        }
+        Value::Array(values) => Value::Array(values.iter().map(canonicalize_value).collect()),
+        _ => value.clone(),
+    }
+}
+
+pub fn system_time_to_i64(time: SystemTime) -> i64 {
+    time.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs() as i64
+}
+
+#[allow(dead_code)]
+pub fn i64_to_system_time(timestamp: i64) -> SystemTime {
+    UNIX_EPOCH + std::time::Duration::from_secs(timestamp.max(0) as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use peerup::crypto::generate_keypair;
+    use serde_json::json;
+
+    #[test]
+    fn canonical_json_orders_keys_recursively() {
+        let value = json!({
+            "z": 1,
+            "a": { "b": 2, "a": 1 }
+        });
+        assert_eq!(canonical_json_string(&value).unwrap(), r#"{"a":{"a":1,"b":2},"z":1}"#);
+    }
+
+    #[test]
+    fn signed_event_round_trips_verification() {
+        let keypair = generate_keypair();
+        let payload = json!({ "status": "up", "monitor_id": "mon-1" });
+
+        let event = SignedEventEnvelope::sign(
+            NewSignedEvent::<_, serde_json::Value> {
+                event_type: "monitor.result.recorded",
+                actor_id: "peer-1",
+                resource_type: "monitor",
+                resource_id: "mon-1",
+                parent_event_id: None,
+                payload: &payload,
+                capability_id: None,
+                delegated_by: None,
+                expires_at: None,
+                context: None,
+            },
+            &keypair,
+        )
+        .unwrap();
+
+        assert!(event.verify().unwrap());
+    }
+}

--- a/apps/service/src/database/migrations.rs
+++ b/apps/service/src/database/migrations.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use libsql::Connection;
 
 /// Schema version - increment when making schema changes
-const SCHEMA_VERSION: i32 = 5;
+const SCHEMA_VERSION: i32 = 6;
 
 /// Run database migrations
 ///
@@ -48,12 +48,19 @@ pub async fn run_migrations(conn: &Connection) -> Result<()> {
 
     if current_version < 4 {
         run_migration_v4(conn).await?;
-        record_migration(conn, 4, "Add public/private monitor visibility and orchestration fields").await?;
+        record_migration(conn, 4, "Add public/private monitor visibility and orchestration fields")
+            .await?;
     }
 
     if current_version < 5 {
         run_migration_v5(conn).await?;
-        record_migration(conn, 5, "Add retention_until and P2P sync columns to peer_results").await?;
+        record_migration(conn, 5, "Add retention_until and P2P sync columns to peer_results")
+            .await?;
+    }
+
+    if current_version < 6 {
+        run_migration_v6(conn).await?;
+        record_migration(conn, 6, "Add signed audit event and attestation tables").await?;
     }
 
     tracing::info!(
@@ -259,6 +266,77 @@ async fn run_migration_v2(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Migration v6: Add signed audit event and attestation tables
+async fn run_migration_v6(conn: &Connection) -> Result<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS audit_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_uuid TEXT NOT NULL UNIQUE,
+            event_type TEXT NOT NULL,
+            schema_version INTEGER NOT NULL,
+            created_at INTEGER NOT NULL,
+            actor_id TEXT NOT NULL,
+            actor_public_key BLOB NOT NULL,
+            resource_type TEXT NOT NULL,
+            resource_id TEXT NOT NULL,
+            parent_event_uuid TEXT,
+            payload_json TEXT NOT NULL,
+            payload_hash TEXT NOT NULL,
+            capability_id TEXT,
+            delegated_by TEXT,
+            expires_at INTEGER,
+            context_json TEXT,
+            signature BLOB NOT NULL
+        )",
+        (),
+    )
+    .await?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS audit_attestations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            attestation_uuid TEXT NOT NULL UNIQUE,
+            subject_event_uuid TEXT NOT NULL,
+            attestor_id TEXT NOT NULL,
+            attestor_public_key BLOB NOT NULL,
+            decision TEXT NOT NULL,
+            reason TEXT,
+            created_at INTEGER NOT NULL,
+            signature BLOB NOT NULL,
+            FOREIGN KEY (subject_event_uuid) REFERENCES audit_events(event_uuid) ON DELETE CASCADE
+        )",
+        (),
+    )
+    .await?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_audit_events_created_at ON audit_events(created_at DESC)",
+        (),
+    )
+    .await?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_audit_events_resource ON audit_events(resource_type, \
+         resource_id, created_at DESC)",
+        (),
+    )
+    .await?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_audit_events_actor ON audit_events(actor_id, created_at \
+         DESC)",
+        (),
+    )
+    .await?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_audit_attestations_subject ON \
+         audit_attestations(subject_event_uuid, created_at DESC)",
+        (),
+    )
+    .await?;
+
+    tracing::info!("Added audit event and attestation tables");
+    Ok(())
+}
+
 /// Migration v3: Add status pages, settings, incidents, and network tables
 async fn run_migration_v3(conn: &Connection) -> Result<()> {
     // ============================================================
@@ -461,40 +539,23 @@ async fn run_migration_v4(conn: &Connection) -> Result<()> {
     tracing::info!("Running migration v4: Add monitor visibility fields");
 
     // Add visibility columns to monitors table
-    conn.execute(
-        "ALTER TABLE monitors ADD COLUMN visibility TEXT NOT NULL DEFAULT 'Private'",
-        (),
-    )
-    .await?;
+    conn.execute("ALTER TABLE monitors ADD COLUMN visibility TEXT NOT NULL DEFAULT 'Private'", ())
+        .await?;
 
-    conn.execute(
-        "ALTER TABLE monitors ADD COLUMN public_domain TEXT",
-        (),
-    )
-    .await?;
+    conn.execute("ALTER TABLE monitors ADD COLUMN public_domain TEXT", ()).await?;
 
-    conn.execute(
-        "ALTER TABLE monitors ADD COLUMN public_display_name TEXT",
-        (),
-    )
-    .await?;
+    conn.execute("ALTER TABLE monitors ADD COLUMN public_display_name TEXT", ())
+        .await?;
 
-    conn.execute(
-        "ALTER TABLE monitors ADD COLUMN owner_peer_id TEXT",
-        (),
-    )
-    .await?;
+    conn.execute("ALTER TABLE monitors ADD COLUMN owner_peer_id TEXT", ()).await?;
 
     // Create indexes for visibility queries
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_monitors_visibility ON monitors(visibility)",
-        (),
-    )
-    .await?;
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_monitors_visibility ON monitors(visibility)", ())
+        .await?;
 
     conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_monitors_public_domain ON monitors(public_domain) \
-         WHERE public_domain IS NOT NULL",
+        "CREATE INDEX IF NOT EXISTS idx_monitors_public_domain ON monitors(public_domain) WHERE \
+         public_domain IS NOT NULL",
         (),
     )
     .await?;
@@ -543,14 +604,14 @@ async fn run_migration_v4(conn: &Connection) -> Result<()> {
 /// Migration v5: Add retention_until and P2P sync columns to peer_results
 /// For databases upgraded from earlier versions that may be missing these columns
 async fn run_migration_v5(conn: &Connection) -> Result<()> {
-    tracing::info!("Running migration v5: Add retention_until and P2P sync columns to peer_results");
+    tracing::info!(
+        "Running migration v5: Add retention_until and P2P sync columns to peer_results"
+    );
 
     // Add source_peer_id column if it doesn't exist
-    match conn.execute(
-        "ALTER TABLE peer_results ADD COLUMN source_peer_id TEXT",
-        (),
-    )
-    .await
+    match conn
+        .execute("ALTER TABLE peer_results ADD COLUMN source_peer_id TEXT", ())
+        .await
     {
         Ok(_) => tracing::debug!("Added source_peer_id column"),
         Err(e) if e.to_string().contains("duplicate column") => {
@@ -560,11 +621,9 @@ async fn run_migration_v5(conn: &Connection) -> Result<()> {
     }
 
     // Add synced_from_peer column if it doesn't exist
-    match conn.execute(
-        "ALTER TABLE peer_results ADD COLUMN synced_from_peer INTEGER DEFAULT 0",
-        (),
-    )
-    .await
+    match conn
+        .execute("ALTER TABLE peer_results ADD COLUMN synced_from_peer INTEGER DEFAULT 0", ())
+        .await
     {
         Ok(_) => tracing::debug!("Added synced_from_peer column"),
         Err(e) if e.to_string().contains("duplicate column") => {
@@ -574,11 +633,9 @@ async fn run_migration_v5(conn: &Connection) -> Result<()> {
     }
 
     // Add retention_until column if it doesn't exist
-    match conn.execute(
-        "ALTER TABLE peer_results ADD COLUMN retention_until INTEGER",
-        (),
-    )
-    .await
+    match conn
+        .execute("ALTER TABLE peer_results ADD COLUMN retention_until INTEGER", ())
+        .await
     {
         Ok(_) => tracing::debug!("Added retention_until column"),
         Err(e) if e.to_string().contains("duplicate column") => {

--- a/apps/service/src/database/models.rs
+++ b/apps/service/src/database/models.rs
@@ -289,3 +289,17 @@ pub struct AuditEvent {
     pub context_json: Option<String>,
     pub signature: Vec<u8>,
 }
+
+/// Peer attestation over a previously stored audit event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditAttestation {
+    pub id: Option<i64>,
+    pub attestation_uuid: Uuid,
+    pub subject_event_uuid: Uuid,
+    pub attestor_id: String,
+    pub attestor_public_key: Vec<u8>,
+    pub decision: String,
+    pub reason: Option<String>,
+    pub created_at: SystemTime,
+    pub signature: Vec<u8>,
+}

--- a/apps/service/src/database/models.rs
+++ b/apps/service/src/database/models.rs
@@ -17,16 +17,16 @@ pub struct Monitor {
     pub enabled: bool,
     pub created_at: SystemTime,
     pub updated_at: SystemTime,
-    
+
     /// Visibility mode (Public or Private)
     pub visibility: MonitorVisibility,
-    
+
     /// Public domain (for public monitors, e.g., "google.com")
     pub public_domain: Option<String>,
-    
+
     /// Display name for public monitors
     pub public_display_name: Option<String>,
-    
+
     /// Owner peer ID (for private monitors)
     pub owner_peer_id: Option<String>,
 }
@@ -69,13 +69,31 @@ impl Monitor {
             owner_peer_id: None,
         }
     }
-    
+
+    /// Derive a deterministic UUID v5 for a public monitor from its domain.
+    /// All peers that see the same domain will produce the identical UUID,
+    /// so results can be aggregated across the network without coordination.
+    pub fn uuid_for_public_domain(domain: &str) -> Uuid {
+        // Fixed application namespace: b"uppe-public-mons" (16 bytes)
+        const NS: Uuid = Uuid::from_bytes([
+            0x75, 0x70, 0x70, 0x65, 0x2d, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, 0x2d, 0x6d, 0x6f,
+            0x6e, 0x73,
+        ]);
+        Uuid::new_v5(&NS, domain.to_lowercase().trim_end_matches('/').as_bytes())
+    }
+
     /// Create a new public monitor
-    pub fn new_public(name: String, target: String, check_type: String, domain: String, display_name: String) -> Self {
+    pub fn new_public(
+        name: String,
+        target: String,
+        check_type: String,
+        domain: String,
+        display_name: String,
+    ) -> Self {
         let now = SystemTime::now();
         Self {
             id: None,
-            uuid: Uuid::new_v4(),
+            uuid: Monitor::uuid_for_public_domain(&domain),
             name,
             target,
             check_type,
@@ -90,67 +108,15 @@ impl Monitor {
             owner_peer_id: None,
         }
     }
-    
-    /// Create a new private monitor with owner (peer-assisted)
-    pub fn new_private(name: String, target: String, check_type: String, owner_peer_id: String) -> Self {
-        let now = SystemTime::now();
-        Self {
-            id: None,
-            uuid: Uuid::new_v4(),
-            name,
-            target,
-            check_type,
-            interval_seconds: 30,
-            timeout_seconds: 10,
-            enabled: true,
-            created_at: now,
-            updated_at: now,
-            visibility: MonitorVisibility::Private,
-            public_domain: None,
-            public_display_name: None,
-            owner_peer_id: Some(owner_peer_id),
-        }
-    }
-    
-    /// Create a new internal monitor (owner-only, secrets)
-    pub fn new_internal(name: String, target: String, check_type: String, owner_peer_id: String) -> Self {
-        let now = SystemTime::now();
-        Self {
-            id: None,
-            uuid: Uuid::new_v4(),
-            name,
-            target,
-            check_type,
-            interval_seconds: 30,
-            timeout_seconds: 10,
-            enabled: true,
-            created_at: now,
-            updated_at: now,
-            visibility: MonitorVisibility::Internal,
-            public_domain: None,
-            public_display_name: None,
-            owner_peer_id: Some(owner_peer_id),
-        }
-    }
-    
+
     /// Check if this is a public monitor
     pub fn is_public(&self) -> bool {
         matches!(self.visibility, MonitorVisibility::Public)
     }
-    
+
     /// Check if this is a private monitor (peer-assisted)
     pub fn is_private(&self) -> bool {
         matches!(self.visibility, MonitorVisibility::Private)
-    }
-    
-    /// Check if this is an internal monitor (owner-only, secrets)
-    pub fn is_internal(&self) -> bool {
-        matches!(self.visibility, MonitorVisibility::Internal)
-    }
-    
-    /// Check if monitor requires peer orchestration
-    pub fn requires_orchestration(&self) -> bool {
-        matches!(self.visibility, MonitorVisibility::Public | MonitorVisibility::Private)
     }
 
     /// Convert SystemTime to Unix timestamp
@@ -300,4 +266,26 @@ pub struct NetworkStats {
     pub checks_performed: i64,
     pub checks_received: i64,
     pub bandwidth_used_mb: i64,
+}
+
+/// Signed audit event persisted in the append-only event log.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditEvent {
+    pub id: Option<i64>,
+    pub event_uuid: Uuid,
+    pub event_type: String,
+    pub schema_version: i32,
+    pub created_at: SystemTime,
+    pub actor_id: String,
+    pub actor_public_key: Vec<u8>,
+    pub resource_type: String,
+    pub resource_id: String,
+    pub parent_event_uuid: Option<Uuid>,
+    pub payload_json: String,
+    pub payload_hash: String,
+    pub capability_id: Option<String>,
+    pub delegated_by: Option<String>,
+    pub expires_at: Option<SystemTime>,
+    pub context_json: Option<String>,
+    pub signature: Vec<u8>,
 }

--- a/apps/service/src/database/repository.rs
+++ b/apps/service/src/database/repository.rs
@@ -5,7 +5,7 @@ use libsql::{Connection, params};
 use std::sync::Arc;
 use uuid::Uuid;
 
-use super::models::{Monitor, MonitorResult, NetworkStats, Peer, PeerResult};
+use super::models::{AuditEvent, Monitor, MonitorResult, NetworkStats, Peer, PeerResult};
 use crate::monitoring::types::CheckResult;
 use crate::pool::LibsqlPool;
 
@@ -67,7 +67,11 @@ pub trait Database: Send + Sync {
     ) -> Result<Vec<PeerResult>>;
 
     /// Mark peer results as synced (for cleanup)
-    async fn mark_peer_results_synced(&self, source_peer_id: &str, until_timestamp: i64) -> Result<()>;
+    async fn mark_peer_results_synced(
+        &self,
+        source_peer_id: &str,
+        until_timestamp: i64,
+    ) -> Result<()>;
 
     /// Clean up expired peer results based on retention policy
     async fn cleanup_expired_peer_results(&self) -> Result<u64>;
@@ -103,6 +107,15 @@ pub trait Database: Send + Sync {
 
     /// Set a setting value by key
     async fn set_setting(&self, key: &str, value: &str) -> Result<()>;
+
+    /// Persist a signed audit event.
+    async fn save_audit_event(&self, event: &AuditEvent) -> Result<i64>;
+
+    /// Fetch a signed audit event by its UUID.
+    async fn get_audit_event(&self, event_uuid: Uuid) -> Result<Option<AuditEvent>>;
+
+    /// List recent signed audit events.
+    async fn list_audit_events(&self, limit: usize) -> Result<Vec<AuditEvent>>;
 }
 
 /// LibSQL database implementation
@@ -128,17 +141,44 @@ impl DatabaseImpl {
     async fn get_conn(&self) -> Result<deadpool::managed::Object<crate::pool::LibsqlManager>> {
         Ok(self.pool.get().await?)
     }
+
+    fn map_audit_event_row(row: &libsql::Row) -> Result<AuditEvent> {
+        let event_uuid: String = row.get(1)?;
+        let created_at: i64 = row.get(4)?;
+        let parent_event_uuid: Option<String> = row.get(9)?;
+        let expires_at: Option<i64> = row.get(14)?;
+
+        Ok(AuditEvent {
+            id: Some(row.get(0)?),
+            event_uuid: Uuid::parse_str(&event_uuid)?,
+            event_type: row.get(2)?,
+            schema_version: row.get(3)?,
+            created_at: Monitor::i64_to_timestamp(created_at),
+            actor_id: row.get(5)?,
+            actor_public_key: row.get(6)?,
+            resource_type: row.get(7)?,
+            resource_id: row.get(8)?,
+            parent_event_uuid: parent_event_uuid.as_deref().map(Uuid::parse_str).transpose()?,
+            payload_json: row.get(10)?,
+            payload_hash: row.get(11)?,
+            capability_id: row.get(12)?,
+            delegated_by: row.get(13)?,
+            expires_at: expires_at.map(Monitor::i64_to_timestamp),
+            context_json: row.get(15)?,
+            signature: row.get(16)?,
+        })
+    }
 }
 
 #[async_trait]
 impl Database for DatabaseImpl {
     async fn get_enabled_monitors(&self) -> Result<Vec<Monitor>> {
         let conn = self.get_conn().await?;
-        let mut stmt = conn
+        let stmt = conn
             .prepare(
                 "SELECT id, uuid, name, target, check_type, interval_seconds, timeout_seconds, \
-                 enabled, created_at, updated_at, visibility, public_domain, \
-                 public_display_name, owner_peer_id FROM monitors WHERE enabled = 1",
+                 enabled, created_at, updated_at, visibility, public_domain, public_display_name, \
+                 owner_peer_id FROM monitors WHERE enabled = 1",
             )
             .await?;
 
@@ -180,11 +220,11 @@ impl Database for DatabaseImpl {
 
     async fn get_monitor_by_uuid(&self, uuid: Uuid) -> Result<Option<Monitor>> {
         let conn = self.get_conn().await?;
-        let mut stmt = conn
+        let stmt = conn
             .prepare(
                 "SELECT id, uuid, name, target, check_type, interval_seconds, timeout_seconds, \
-                 enabled, created_at, updated_at, visibility, public_domain, \
-                 public_display_name, owner_peer_id FROM monitors WHERE uuid = ?",
+                 enabled, created_at, updated_at, visibility, public_domain, public_display_name, \
+                 owner_peer_id FROM monitors WHERE uuid = ?",
             )
             .await?;
 
@@ -239,8 +279,8 @@ impl Database for DatabaseImpl {
             // Update existing monitor
             conn.execute(
                 "UPDATE monitors SET name = ?, target = ?, check_type = ?, interval_seconds = ?, \
-                 timeout_seconds = ?, enabled = ?, updated_at = ?, visibility = ?, \
-                 public_domain = ?, public_display_name = ?, owner_peer_id = ? WHERE id = ?",
+                 timeout_seconds = ?, enabled = ?, updated_at = ?, visibility = ?, public_domain \
+                 = ?, public_display_name = ?, owner_peer_id = ? WHERE id = ?",
                 params![
                     monitor.name.clone(),
                     monitor.target.clone(),
@@ -262,9 +302,9 @@ impl Database for DatabaseImpl {
             // Insert new monitor
             conn.execute(
                 "INSERT INTO monitors (uuid, name, target, check_type, interval_seconds, \
-                 timeout_seconds, enabled, created_at, updated_at, visibility, \
-                 public_domain, public_display_name, owner_peer_id) VALUES (?, ?, ?, ?, ?, ?, ?, \
-                 ?, ?, ?, ?, ?, ?)",
+                 timeout_seconds, enabled, created_at, updated_at, visibility, public_domain, \
+                 public_display_name, owner_peer_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, \
+                 ?)",
                 params![
                     monitor.uuid.to_string(),
                     monitor.name.clone(),
@@ -374,7 +414,7 @@ impl Database for DatabaseImpl {
         limit: usize,
     ) -> Result<Vec<MonitorResult>> {
         let conn = self.get_conn().await?;
-        let mut stmt = conn
+        let stmt = conn
             .prepare(
                 "SELECT id, monitor_uuid, timestamp, status, latency_ms, status_code, \
                  error_message, peer_id, signature, created_at, city, country, region FROM \
@@ -418,7 +458,7 @@ impl Database for DatabaseImpl {
 
     async fn get_peer_results(&self, monitor_uuid: Uuid, limit: usize) -> Result<Vec<PeerResult>> {
         let conn = self.get_conn().await?;
-        let mut stmt = conn
+        let stmt = conn
             .prepare(
                 "SELECT id, monitor_uuid, timestamp, status, latency_ms, status_code, \
                  error_message, peer_id, signature, verified, created_at FROM peer_results WHERE \
@@ -508,16 +548,17 @@ impl Database for DatabaseImpl {
 
     async fn get_peer_by_id(&self, peer_id: &str) -> Result<Option<Peer>> {
         let conn = self.get_conn().await?;
-        
+
         let mut rows = conn
             .query(
                 "SELECT peer_id, status, last_seen, joined_at, contribution_score, \
-                 uptime_percentage, checks_per_day, location_city, location_region, location_country
+                 uptime_percentage, checks_per_day, location_city, location_region, \
+                 location_country
                  FROM peers WHERE peer_id = ?",
                 params![peer_id],
             )
             .await?;
-        
+
         if let Some(row) = rows.next().await? {
             let peer_id: String = row.get(0)?;
             let status: String = row.get(1)?;
@@ -529,10 +570,10 @@ impl Database for DatabaseImpl {
             let location_city: Option<String> = row.get(7)?;
             let location_region: Option<String> = row.get(8)?;
             let location_country: Option<String> = row.get(9)?;
-            
+
             let last_seen = Monitor::i64_to_timestamp(last_seen_i64);
             let joined_at = Monitor::i64_to_timestamp(joined_at_i64);
-            
+
             Ok(Some(Peer {
                 peer_id,
                 status,
@@ -553,11 +594,11 @@ impl Database for DatabaseImpl {
     async fn list_peers(&self, limit: usize) -> Result<Vec<Peer>> {
         let conn = self.get_conn().await?;
 
-        let mut stmt = conn
+        let stmt = conn
             .prepare(
                 "SELECT peer_id, status, last_seen, joined_at, contribution_score, \
-                 uptime_percentage, checks_per_day, location_city, location_region, location_country\
-                 FROM peers ORDER BY last_seen DESC LIMIT ?",
+                 uptime_percentage, checks_per_day, location_city, location_region, \
+                 location_countryFROM peers ORDER BY last_seen DESC LIMIT ?",
             )
             .await?;
 
@@ -617,7 +658,7 @@ impl Database for DatabaseImpl {
 
     async fn get_latest_network_stats(&self) -> Result<Option<NetworkStats>> {
         let conn = self.get_conn().await?;
-        let mut stmt = conn
+        let stmt = conn
             .prepare(
                 "SELECT timestamp, total_peers, online_peers, checks_performed, checks_received, \
                  bandwidth_used_mb
@@ -649,16 +690,14 @@ impl Database for DatabaseImpl {
         limit: usize,
     ) -> Result<Vec<PeerResult>> {
         let conn = self.get_conn().await?;
-        
+
         let (query, _params_list): (String, Vec<String>) = if let Some(uuid) = monitor_uuid {
             (
                 format!(
                     "SELECT id, monitor_uuid, timestamp, status, latency_ms, status_code, \
                      error_message, peer_id, signature, verified, created_at, city, country, \
-                     region, source_peer_id, synced_from_peer, retention_until \
-                     FROM peer_results \
-                     WHERE timestamp > ? AND monitor_uuid = ? \
-                     ORDER BY timestamp DESC LIMIT {}",
+                     region, source_peer_id, synced_from_peer, retention_until FROM peer_results \
+                     WHERE timestamp > ? AND monitor_uuid = ? ORDER BY timestamp DESC LIMIT {}",
                     limit
                 ),
                 vec![since_timestamp.to_string(), uuid.to_string()],
@@ -668,18 +707,16 @@ impl Database for DatabaseImpl {
                 format!(
                     "SELECT id, monitor_uuid, timestamp, status, latency_ms, status_code, \
                      error_message, peer_id, signature, verified, created_at, city, country, \
-                     region, source_peer_id, synced_from_peer, retention_until \
-                     FROM peer_results \
-                     WHERE timestamp > ? \
-                     ORDER BY timestamp DESC LIMIT {}",
+                     region, source_peer_id, synced_from_peer, retention_until FROM peer_results \
+                     WHERE timestamp > ? ORDER BY timestamp DESC LIMIT {}",
                     limit
                 ),
                 vec![since_timestamp.to_string()],
             )
         };
 
-        let mut stmt = conn.prepare(&query).await?;
-        
+        let stmt = conn.prepare(&query).await?;
+
         let mut rows = if let Some(uuid) = monitor_uuid {
             stmt.query(params![since_timestamp, uuid.to_string()]).await?
         } else {
@@ -725,12 +762,16 @@ impl Database for DatabaseImpl {
         Ok(results)
     }
 
-    async fn mark_peer_results_synced(&self, source_peer_id: &str, until_timestamp: i64) -> Result<()> {
+    async fn mark_peer_results_synced(
+        &self,
+        source_peer_id: &str,
+        until_timestamp: i64,
+    ) -> Result<()> {
         let conn = self.get_conn().await?;
 
         conn.execute(
-            "UPDATE peer_results SET synced_from_peer = 1 \
-             WHERE source_peer_id = ? AND timestamp <= ?",
+            "UPDATE peer_results SET synced_from_peer = 1 WHERE source_peer_id = ? AND timestamp \
+             <= ?",
             params![source_peer_id, until_timestamp],
         )
         .await?;
@@ -747,9 +788,8 @@ impl Database for DatabaseImpl {
 
         let result = conn
             .execute(
-                "DELETE FROM peer_results \
-                 WHERE retention_until IS NOT NULL AND retention_until < ? \
-                 AND synced_from_peer = 1",
+                "DELETE FROM peer_results WHERE retention_until IS NOT NULL AND retention_until < \
+                 ? AND synced_from_peer = 1",
                 params![now],
             )
             .await?;
@@ -765,12 +805,10 @@ impl Database for DatabaseImpl {
     ) -> Result<Option<peerup::distributed::PublicMonitorGroup>> {
         let conn = self.get_conn().await?;
 
-        let mut stmt = conn
+        let stmt = conn
             .prepare(
-                "SELECT domain, display_name, participating_peers, schedule_json, \
-                 total_checks, created_at, last_updated \
-                 FROM public_monitor_groups \
-                 WHERE domain = ?",
+                "SELECT domain, display_name, participating_peers, schedule_json, total_checks, \
+                 created_at, last_updated FROM public_monitor_groups WHERE domain = ?",
             )
             .await?;
 
@@ -780,8 +818,7 @@ impl Database for DatabaseImpl {
             let participating_peers_json: String = row.get(2)?;
             let schedule_json: String = row.get(3)?;
 
-            let participating_peers: Vec<String> =
-                serde_json::from_str(&participating_peers_json)?;
+            let participating_peers: Vec<String> = serde_json::from_str(&participating_peers_json)?;
             let schedule: peerup::distributed::OrchestrationSchedule =
                 serde_json::from_str(&schedule_json)?;
 
@@ -811,16 +848,12 @@ impl Database for DatabaseImpl {
         let schedule_json = serde_json::to_string(&group.schedule)?;
 
         conn.execute(
-            "INSERT INTO public_monitor_groups \
-             (domain, display_name, participating_peers, schedule_json, \
-              total_checks, created_at, last_updated) \
-             VALUES (?, ?, ?, ?, ?, ?, ?) \
-             ON CONFLICT(domain) DO UPDATE SET \
-             display_name = excluded.display_name, \
-             participating_peers = excluded.participating_peers, \
-             schedule_json = excluded.schedule_json, \
-             total_checks = excluded.total_checks, \
-             last_updated = excluded.last_updated",
+            "INSERT INTO public_monitor_groups (domain, display_name, participating_peers, \
+             schedule_json, total_checks, created_at, last_updated) VALUES (?, ?, ?, ?, ?, ?, ?) \
+             ON CONFLICT(domain) DO UPDATE SET display_name = excluded.display_name, \
+             participating_peers = excluded.participating_peers, schedule_json = \
+             excluded.schedule_json, total_checks = excluded.total_checks, last_updated = \
+             excluded.last_updated",
             params![
                 group.domain.clone(),
                 group.display_name.clone(),
@@ -842,12 +875,10 @@ impl Database for DatabaseImpl {
     ) -> Result<Vec<peerup::distributed::OrchestrationVote>> {
         let conn = self.get_conn().await?;
 
-        let mut stmt = conn
+        let stmt = conn
             .prepare(
-                "SELECT domain, voter_peer_id, schedule_json, signature, timestamp \
-                 FROM orchestration_votes \
-                 WHERE domain = ? \
-                 ORDER BY timestamp DESC",
+                "SELECT domain, voter_peer_id, schedule_json, signature, timestamp FROM \
+                 orchestration_votes WHERE domain = ? ORDER BY timestamp DESC",
             )
             .await?;
 
@@ -881,13 +912,10 @@ impl Database for DatabaseImpl {
         let schedule_json = serde_json::to_string(&vote.schedule)?;
 
         conn.execute(
-            "INSERT INTO orchestration_votes \
-             (domain, voter_peer_id, schedule_json, signature, timestamp) \
-             VALUES (?, ?, ?, ?, ?) \
-             ON CONFLICT(domain, voter_peer_id) DO UPDATE SET \
-             schedule_json = excluded.schedule_json, \
-             signature = excluded.signature, \
-             timestamp = excluded.timestamp",
+            "INSERT INTO orchestration_votes (domain, voter_peer_id, schedule_json, signature, \
+             timestamp) VALUES (?, ?, ?, ?, ?) ON CONFLICT(domain, voter_peer_id) DO UPDATE SET \
+             schedule_json = excluded.schedule_json, signature = excluded.signature, timestamp = \
+             excluded.timestamp",
             params![
                 vote.domain.clone(),
                 vote.voter_peer_id.clone(),
@@ -903,12 +931,7 @@ impl Database for DatabaseImpl {
 
     async fn get_setting(&self, key: &str) -> Result<Option<String>> {
         let conn = self.get_conn().await?;
-        let mut rows = conn
-            .query(
-                "SELECT value FROM settings WHERE key = ?",
-                params![key],
-            )
-            .await?;
+        let mut rows = conn.query("SELECT value FROM settings WHERE key = ?", params![key]).await?;
 
         if let Some(row) = rows.next().await? {
             let value: String = row.get(0)?;
@@ -922,11 +945,130 @@ impl Database for DatabaseImpl {
         let conn = self.get_conn().await?;
         let now = crate::database::models::Monitor::timestamp_to_i64(std::time::SystemTime::now());
         conn.execute(
-            "INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?) \
-             ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+            "INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?) ON CONFLICT(key) DO \
+             UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
             params![key, value, now],
         )
         .await?;
         Ok(())
+    }
+
+    async fn save_audit_event(&self, event: &AuditEvent) -> Result<i64> {
+        let conn = self.get_conn().await?;
+
+        conn.execute(
+            "INSERT INTO audit_events (
+                event_uuid,
+                event_type,
+                schema_version,
+                created_at,
+                actor_id,
+                actor_public_key,
+                resource_type,
+                resource_id,
+                parent_event_uuid,
+                payload_json,
+                payload_hash,
+                capability_id,
+                delegated_by,
+                expires_at,
+                context_json,
+                signature
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            params![
+                event.event_uuid.to_string(),
+                event.event_type.clone(),
+                event.schema_version,
+                Monitor::timestamp_to_i64(event.created_at),
+                event.actor_id.clone(),
+                event.actor_public_key.clone(),
+                event.resource_type.clone(),
+                event.resource_id.clone(),
+                event.parent_event_uuid.map(|uuid| uuid.to_string()),
+                event.payload_json.clone(),
+                event.payload_hash.clone(),
+                event.capability_id.clone(),
+                event.delegated_by.clone(),
+                event.expires_at.map(Monitor::timestamp_to_i64),
+                event.context_json.clone(),
+                event.signature.clone(),
+            ],
+        )
+        .await?;
+
+        let row_id = conn.last_insert_rowid();
+        Ok(row_id)
+    }
+
+    async fn get_audit_event(&self, event_uuid: Uuid) -> Result<Option<AuditEvent>> {
+        let conn = self.get_conn().await?;
+        let mut rows = conn
+            .query(
+                "SELECT
+                    id,
+                    event_uuid,
+                    event_type,
+                    schema_version,
+                    created_at,
+                    actor_id,
+                    actor_public_key,
+                    resource_type,
+                    resource_id,
+                    parent_event_uuid,
+                    payload_json,
+                    payload_hash,
+                    capability_id,
+                    delegated_by,
+                    expires_at,
+                    context_json,
+                    signature
+                 FROM audit_events
+                 WHERE event_uuid = ?",
+                params![event_uuid.to_string()],
+            )
+            .await?;
+
+        if let Some(row) = rows.next().await? {
+            Ok(Some(Self::map_audit_event_row(&row)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn list_audit_events(&self, limit: usize) -> Result<Vec<AuditEvent>> {
+        let conn = self.get_conn().await?;
+        let mut rows = conn
+            .query(
+                "SELECT
+                    id,
+                    event_uuid,
+                    event_type,
+                    schema_version,
+                    created_at,
+                    actor_id,
+                    actor_public_key,
+                    resource_type,
+                    resource_id,
+                    parent_event_uuid,
+                    payload_json,
+                    payload_hash,
+                    capability_id,
+                    delegated_by,
+                    expires_at,
+                    context_json,
+                    signature
+                 FROM audit_events
+                 ORDER BY created_at DESC, id DESC
+                 LIMIT ?",
+                params![limit as i64],
+            )
+            .await?;
+
+        let mut events = Vec::new();
+        while let Some(row) = rows.next().await? {
+            events.push(Self::map_audit_event_row(&row)?);
+        }
+
+        Ok(events)
     }
 }

--- a/apps/service/src/database/repository.rs
+++ b/apps/service/src/database/repository.rs
@@ -5,7 +5,9 @@ use libsql::{Connection, params};
 use std::sync::Arc;
 use uuid::Uuid;
 
-use super::models::{AuditEvent, Monitor, MonitorResult, NetworkStats, Peer, PeerResult};
+use super::models::{
+    AuditAttestation, AuditEvent, Monitor, MonitorResult, NetworkStats, Peer, PeerResult,
+};
 use crate::monitoring::types::CheckResult;
 use crate::pool::LibsqlPool;
 
@@ -116,6 +118,15 @@ pub trait Database: Send + Sync {
 
     /// List recent signed audit events.
     async fn list_audit_events(&self, limit: usize) -> Result<Vec<AuditEvent>>;
+
+    /// Persist a signed audit attestation.
+    async fn save_audit_attestation(&self, attestation: &AuditAttestation) -> Result<i64>;
+
+    /// List attestations associated with an audit event.
+    async fn list_audit_attestations(
+        &self,
+        subject_event_uuid: Uuid,
+    ) -> Result<Vec<AuditAttestation>>;
 }
 
 /// LibSQL database implementation
@@ -166,6 +177,24 @@ impl DatabaseImpl {
             expires_at: expires_at.map(Monitor::i64_to_timestamp),
             context_json: row.get(15)?,
             signature: row.get(16)?,
+        })
+    }
+
+    fn map_audit_attestation_row(row: &libsql::Row) -> Result<AuditAttestation> {
+        let attestation_uuid: String = row.get(1)?;
+        let subject_event_uuid: String = row.get(2)?;
+        let created_at: i64 = row.get(7)?;
+
+        Ok(AuditAttestation {
+            id: Some(row.get(0)?),
+            attestation_uuid: Uuid::parse_str(&attestation_uuid)?,
+            subject_event_uuid: Uuid::parse_str(&subject_event_uuid)?,
+            attestor_id: row.get(3)?,
+            attestor_public_key: row.get(4)?,
+            decision: row.get(5)?,
+            reason: row.get(6)?,
+            created_at: Monitor::i64_to_timestamp(created_at),
+            signature: row.get(8)?,
         })
     }
 }
@@ -1070,5 +1099,67 @@ impl Database for DatabaseImpl {
         }
 
         Ok(events)
+    }
+
+    async fn save_audit_attestation(&self, attestation: &AuditAttestation) -> Result<i64> {
+        let conn = self.get_conn().await?;
+
+        conn.execute(
+            "INSERT INTO audit_attestations (
+                attestation_uuid,
+                subject_event_uuid,
+                attestor_id,
+                attestor_public_key,
+                decision,
+                reason,
+                created_at,
+                signature
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            params![
+                attestation.attestation_uuid.to_string(),
+                attestation.subject_event_uuid.to_string(),
+                attestation.attestor_id.clone(),
+                attestation.attestor_public_key.clone(),
+                attestation.decision.clone(),
+                attestation.reason.clone(),
+                Monitor::timestamp_to_i64(attestation.created_at),
+                attestation.signature.clone(),
+            ],
+        )
+        .await?;
+
+        Ok(conn.last_insert_rowid())
+    }
+
+    async fn list_audit_attestations(
+        &self,
+        subject_event_uuid: Uuid,
+    ) -> Result<Vec<AuditAttestation>> {
+        let conn = self.get_conn().await?;
+        let mut rows = conn
+            .query(
+                "SELECT
+                    id,
+                    attestation_uuid,
+                    subject_event_uuid,
+                    attestor_id,
+                    attestor_public_key,
+                    decision,
+                    reason,
+                    created_at,
+                    signature
+                 FROM audit_attestations
+                 WHERE subject_event_uuid = ?
+                 ORDER BY created_at DESC, id DESC",
+                params![subject_event_uuid.to_string()],
+            )
+            .await?;
+
+        let mut attestations = Vec::new();
+        while let Some(row) = rows.next().await? {
+            attestations.push(Self::map_audit_attestation_row(&row)?);
+        }
+
+        Ok(attestations)
     }
 }

--- a/apps/service/src/main.rs
+++ b/apps/service/src/main.rs
@@ -245,6 +245,24 @@ async fn main() -> anyhow::Result<()> {
                     monitor.interval_seconds = interval;
                     monitor.timeout_seconds = timeout;
                     let id = dbi.save_monitor(&monitor).await?;
+                    match audit::load_local_keypair() {
+                        Ok(keypair) => {
+                            let actor_id = keypair.public_key_hex();
+                            if let Err(e) = audit::record_monitor_event(
+                                &dbi, &keypair, &actor_id, "created", &monitor,
+                            )
+                            .await
+                            {
+                                tracing::warn!(
+                                    "Failed to record monitor create audit event: {}",
+                                    e
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("Failed to load local audit keypair: {}", e);
+                        }
+                    }
                     println!("Added monitor with id {} and uuid {}", id, monitor.uuid);
                 }
             }

--- a/apps/service/src/main.rs
+++ b/apps/service/src/main.rs
@@ -3,6 +3,7 @@ use std::path;
 
 use clap::{Parser, Subcommand, crate_authors, crate_version};
 
+mod audit;
 mod config;
 mod crypto;
 mod database;

--- a/apps/service/src/monitoring/scheduler.rs
+++ b/apps/service/src/monitoring/scheduler.rs
@@ -16,6 +16,11 @@ pub struct MonitorConfig {
     pub check_type: CheckType,
     pub interval_seconds: u64,
     pub enabled: bool,
+    /// How many seconds to wait before the first check.
+    /// Used to stagger checks across peers so they don't all hit the
+    /// target at the same instant.  0 = start after one full interval
+    /// (original behaviour).
+    pub phase_offset_secs: u64,
 }
 
 /// Monitoring scheduler - coordinates execution of monitoring tasks
@@ -40,8 +45,22 @@ impl MonitoringScheduler {
                 return;
             }
 
-            let duration = Duration::from_secs(config.interval_seconds);
-            let mut timer = interval_at(Instant::now() + duration, duration);
+            let period = Duration::from_secs(config.interval_seconds);
+
+            // When a phase offset is specified, start the first tick at
+            // `now + phase_offset` and then tick every `interval`.  This
+            // staggers checks across peers so at most one peer hits the
+            // target at any given second.
+            // With no offset (or offset ≥ interval) fall back to the
+            // original "first check after one full interval" behaviour.
+            let first_tick = if config.phase_offset_secs > 0
+                && config.phase_offset_secs < config.interval_seconds
+            {
+                Instant::now() + Duration::from_secs(config.phase_offset_secs)
+            } else {
+                Instant::now() + period
+            };
+            let mut timer = interval_at(first_tick, period);
 
             loop {
                 timer.tick().await;
@@ -57,14 +76,6 @@ impl MonitoringScheduler {
                 }
             }
         })
-    }
-
-    /// Schedule multiple monitors
-    pub fn schedule_monitors(
-        &self,
-        configs: Vec<MonitorConfig>,
-    ) -> Vec<tokio::task::JoinHandle<()>> {
-        configs.into_iter().map(|config| self.schedule_monitor(config)).collect()
     }
 }
 
@@ -86,6 +97,7 @@ mod tests {
             check_type: CheckType::Https,
             interval_seconds: 1,
             enabled: true,
+            phase_offset_secs: 0,
         };
 
         let _handle = scheduler.schedule_monitor(config);

--- a/apps/service/src/orchestrator/admin_trust.rs
+++ b/apps/service/src/orchestrator/admin_trust.rs
@@ -1,7 +1,9 @@
+#![allow(dead_code)] // Future infrastructure — admin key rotation not yet wired
+
 //! Admin Trust Chain System
 //!
 //! Secure, auto-updating admin authentication using HTTPS bootstrap + DHT caching.
-//! 
+//!
 //! ## Architecture:
 //! 1. **HTTPS Bootstrap**: Fetch initial admin keys from keys.uppe.dev (Git-tracked)
 //! 2. **DHT Caching**: Cache keys in DHT for offline/decentralized operation
@@ -17,16 +19,16 @@
 //! - Each key has expiry timestamp (max 1 year)
 //! - Revoked keys published to DHT and HTTPS
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Bootstrap URLs for fetching admin trust chain (tried in order)
 pub const ADMIN_KEY_BOOTSTRAP_URLS: &[&str] = &[
-    "https://keys.uppe.dev/admin-trust-chain.json",                             // Primary CDN
-    "https://uppe.github.io/keys/admin-trust-chain.json",                       // GitHub Pages
-    "https://raw.githubusercontent.com/Obiente/Uppe/main/admin-keys.json",     // Raw GitHub
+    "https://keys.uppe.dev/admin-trust-chain.json", // Primary CDN
+    "https://uppe.github.io/keys/admin-trust-chain.json", // GitHub Pages
+    "https://raw.githubusercontent.com/Obiente/Uppe/main/admin-keys.json", // Raw GitHub
 ];
 
 /// DHT key for admin trust chain (cached by all nodes)
@@ -46,16 +48,16 @@ pub const UPDATE_CHECK_INTERVAL_SECS: u64 = 3600;
 pub struct AdminKey {
     /// Ed25519 public key (base64 encoded)
     pub public_key: String,
-    
+
     /// When this key becomes valid
     pub valid_from: u64,
-    
+
     /// When this key expires
     pub valid_until: u64,
-    
+
     /// Key identifier (first 8 bytes of public key hash)
     pub key_id: String,
-    
+
     /// Human-readable description
     pub description: String,
 }
@@ -67,20 +69,20 @@ impl AdminKey {
             .duration_since(UNIX_EPOCH)
             .unwrap_or_else(|_| Duration::from_secs(0))
             .as_secs();
-        
+
         now >= self.valid_from && now <= self.valid_until
     }
-    
+
     /// Check if key is expired
     pub fn is_expired(&self) -> bool {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_else(|_| Duration::from_secs(0))
             .as_secs();
-        
+
         now > self.valid_until
     }
-    
+
     /// Generate key ID from public key
     pub fn compute_key_id(public_key: &str) -> String {
         use sha2::{Digest, Sha256};
@@ -94,16 +96,16 @@ impl AdminKey {
 pub struct KeyRotation {
     /// The new key being activated
     pub new_key: AdminKey,
-    
+
     /// Key ID of the previous key that signed this
     pub signed_by_key_id: String,
-    
+
     /// Ed25519 signature over new_key (signed by previous key)
     pub signature: Vec<u8>,
-    
+
     /// Timestamp when rotation was performed
     pub rotated_at: u64,
-    
+
     /// Reason for rotation
     pub reason: String,
 }
@@ -115,10 +117,12 @@ impl KeyRotation {
         if previous_key.key_id != self.signed_by_key_id {
             return Ok(false);
         }
-        
-        // For now, simplified verification (would use Ed25519 in production)
-        // TODO: Implement proper Ed25519 signature verification using message serialization
-        Ok(self.signature.len() == 64) // Placeholder
+
+        verify_admin_signature_bytes(
+            &previous_key.public_key,
+            &canonical_rotation_bytes(&self.new_key)?,
+            &self.signature,
+        )
     }
 }
 
@@ -127,22 +131,22 @@ impl KeyRotation {
 pub struct RevocationList {
     /// Key IDs that have been revoked
     pub revoked_keys: HashSet<String>,
-    
+
     /// Reason for each revocation
     pub revocation_reasons: HashMap<String, String>,
-    
+
     /// When each key was revoked
     pub revoked_at: HashMap<String, u64>,
-    
+
     /// Signature over this revocation list (signed by current admin key)
     pub signature: Vec<u8>,
-    
+
     /// Key ID that signed this CRL
     pub signed_by_key_id: String,
-    
+
     /// CRL version number (increments on each update)
     pub version: u64,
-    
+
     /// When this CRL was issued
     pub issued_at: u64,
 }
@@ -152,17 +156,79 @@ impl RevocationList {
     pub fn is_revoked(&self, key_id: &str) -> bool {
         self.revoked_keys.contains(key_id)
     }
-    
+
     /// Verify CRL signature
     pub fn verify(&self, signing_key: &AdminKey) -> Result<bool> {
         if signing_key.key_id != self.signed_by_key_id {
             return Ok(false);
         }
-        
-        // Simplified verification (would use Ed25519 in production)
-        // TODO: Implement proper Ed25519 signature verification
-        Ok(self.signature.len() == 64) // Placeholder
+
+        verify_admin_signature_bytes(
+            &signing_key.public_key,
+            &canonical_revocation_list_bytes(self)?,
+            &self.signature,
+        )
     }
+}
+
+fn canonical_rotation_bytes(new_key: &AdminKey) -> Result<Vec<u8>> {
+    Ok(serde_json::to_vec(new_key)?)
+}
+
+fn canonical_revocation_list_bytes(revocation_list: &RevocationList) -> Result<Vec<u8>> {
+    #[derive(Serialize)]
+    struct SignableRevocationList<'a> {
+        revoked_keys: BTreeSet<&'a str>,
+        revocation_reasons: BTreeMap<&'a str, &'a str>,
+        revoked_at: BTreeMap<&'a str, u64>,
+        signed_by_key_id: &'a str,
+        version: u64,
+        issued_at: u64,
+    }
+
+    let revoked_keys = revocation_list.revoked_keys.iter().map(String::as_str).collect();
+    let revocation_reasons = revocation_list
+        .revocation_reasons
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect();
+    let revoked_at = revocation_list
+        .revoked_at
+        .iter()
+        .map(|(key, value)| (key.as_str(), *value))
+        .collect();
+
+    Ok(serde_json::to_vec(&SignableRevocationList {
+        revoked_keys,
+        revocation_reasons,
+        revoked_at,
+        signed_by_key_id: &revocation_list.signed_by_key_id,
+        version: revocation_list.version,
+        issued_at: revocation_list.issued_at,
+    })?)
+}
+
+fn verify_admin_signature_bytes(
+    public_key_b64: &str,
+    message: &[u8],
+    signature: &[u8],
+) -> Result<bool> {
+    use base64::{Engine, engine::general_purpose};
+    use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+
+    let public_key_bytes = general_purpose::STANDARD.decode(public_key_b64)?;
+    let key_array: [u8; 32] = public_key_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow!("Invalid public key length"))?;
+    let sig_array: [u8; 64] =
+        signature.try_into().map_err(|_| anyhow!("Invalid signature length"))?;
+
+    let public_key =
+        VerifyingKey::from_bytes(&key_array).map_err(|e| anyhow!("Invalid public key: {}", e))?;
+    let sig = Signature::from_bytes(&sig_array);
+
+    Ok(public_key.verify(message, &sig).is_ok())
 }
 
 /// Admin trust chain - verifiable path from root keys to current keys
@@ -170,16 +236,16 @@ impl RevocationList {
 pub struct AdminTrustChain {
     /// All key rotations in chronological order
     pub rotations: Vec<KeyRotation>,
-    
+
     /// Current valid admin keys
     pub current_keys: Vec<AdminKey>,
-    
+
     /// Certificate Revocation List
     pub revocation_list: RevocationList,
-    
+
     /// When this chain was last updated
     pub last_updated: u64,
-    
+
     /// Version number (increments on each update)
     pub version: u64,
 }
@@ -187,12 +253,10 @@ pub struct AdminTrustChain {
 impl AdminTrustChain {
     /// Bootstrap from HTTPS (tries multiple URLs)
     pub async fn bootstrap_from_https() -> Result<Self> {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .build()?;
-        
+        let client = reqwest::Client::builder().timeout(Duration::from_secs(10)).build()?;
+
         let mut last_error = None;
-        
+
         for url in ADMIN_KEY_BOOTSTRAP_URLS {
             match client.get(*url).send().await {
                 Ok(response) => {
@@ -218,13 +282,16 @@ impl AdminTrustChain {
                 }
             }
         }
-        
+
         Err(last_error.unwrap_or_else(|| anyhow!("All bootstrap URLs failed")))
     }
-    
+
     /// Create empty chain (for testing)
     pub fn empty() -> Self {
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_else(|_| Duration::from_secs(0)).as_secs();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|_| Duration::from_secs(0))
+            .as_secs();
         Self {
             rotations: Vec::new(),
             current_keys: Vec::new(),
@@ -241,64 +308,62 @@ impl AdminTrustChain {
             version: 0,
         }
     }
-    
+
     /// Verify entire chain from initial keys to current keys
     pub fn verify(&self) -> Result<bool> {
         // Start with initial keys in the chain
         if self.current_keys.is_empty() {
             return Ok(false);
         }
-        
+
         let mut current_keys = self.current_keys.clone();
-        
+
         // Verify each rotation in sequence
         for rotation in &self.rotations {
             // Find the key that signed this rotation
-            let signing_key = current_keys
-                .iter()
-                .find(|k| k.key_id == rotation.signed_by_key_id)
-                .ok_or_else(|| anyhow!("Rotation signed by unknown key: {}", rotation.signed_by_key_id))?;
-            
+            let signing_key =
+                current_keys.iter().find(|k| k.key_id == rotation.signed_by_key_id).ok_or_else(
+                    || anyhow!("Rotation signed by unknown key: {}", rotation.signed_by_key_id),
+                )?;
+
             // Verify the signature
             if !rotation.verify(signing_key)? {
                 return Ok(false);
             }
-            
+
             // Check if signing key was revoked
             if self.revocation_list.is_revoked(&signing_key.key_id) {
                 return Ok(false);
             }
-            
+
             // Add new key to current set
             current_keys.push(rotation.new_key.clone());
         }
-        
+
         // Verify revocation list is signed by a current key
         if !self.revocation_list.signature.is_empty() {
             let crl_signing_key = current_keys
                 .iter()
                 .find(|k| k.key_id == self.revocation_list.signed_by_key_id)
                 .ok_or_else(|| anyhow!("CRL signed by unknown key"))?;
-            
+
             if !self.revocation_list.verify(crl_signing_key)? {
                 return Ok(false);
             }
         }
-        
+
         Ok(true)
     }
-    
+
     /// Get all currently valid admin keys (not expired, not revoked)
     pub fn get_valid_keys(&self) -> Vec<AdminKey> {
         self.current_keys
             .iter()
-            .filter(|k| {
-                k.is_valid() && !self.revocation_list.is_revoked(&k.key_id)
-            })
+            .filter(|k| k.is_valid() && !self.revocation_list.is_revoked(&k.key_id))
             .cloned()
             .collect()
     }
-    
+
     /// Check if a peer ID is an admin
     pub fn is_admin(&self, peer_id: &str) -> bool {
         // In practice, would map peer_id to public key and check against valid keys
@@ -309,49 +374,51 @@ impl AdminTrustChain {
             k.key_id == peer_id
         })
     }
-    
+
     /// Apply a new rotation (admin operation)
     pub fn apply_rotation(&mut self, rotation: KeyRotation) -> Result<()> {
         // Verify rotation is valid
-        let signing_key = self.current_keys
+        let signing_key = self
+            .current_keys
             .iter()
             .find(|k| k.key_id == rotation.signed_by_key_id)
             .ok_or_else(|| anyhow!("Unknown signing key"))?;
-        
+
         if !rotation.verify(signing_key)? {
             anyhow::bail!("Invalid rotation signature");
         }
-        
+
         self.rotations.push(rotation.clone());
         self.current_keys.push(rotation.new_key);
         self.last_updated = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
         self.version += 1;
-        
+
         Ok(())
     }
-    
+
     /// Update revocation list (admin operation)
     pub fn update_revocation_list(&mut self, revocation_list: RevocationList) -> Result<()> {
         // Verify CRL is signed by a current valid key
-        let signing_key = self.get_valid_keys()
+        let signing_key = self
+            .get_valid_keys()
             .iter()
             .find(|k| k.key_id == revocation_list.signed_by_key_id)
             .ok_or_else(|| anyhow!("CRL signed by non-admin key"))?
             .clone();
-        
+
         if !revocation_list.verify(&signing_key)? {
             anyhow::bail!("Invalid CRL signature");
         }
-        
+
         // Must be newer than current CRL
         if revocation_list.version <= self.revocation_list.version {
             anyhow::bail!("CRL version must be newer");
         }
-        
+
         self.revocation_list = revocation_list;
         self.last_updated = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
         self.version += 1;
-        
+
         Ok(())
     }
 }
@@ -370,13 +437,13 @@ pub enum BootstrapStatus {
 pub struct AdminTrustManager {
     /// Current trust chain
     chain: AdminTrustChain,
-    
+
     /// Last time we queried for updates
     last_update_check: SystemTime,
-    
+
     /// How often to check for updates
     check_interval: Duration,
-    
+
     /// Bootstrap status (for UI)
     pub bootstrap_status: BootstrapStatus,
 }
@@ -390,7 +457,7 @@ impl AdminTrustManager {
             check_interval: Duration::from_secs(UPDATE_CHECK_INTERVAL_SECS),
             bootstrap_status: BootstrapStatus::NotStarted,
         };
-        
+
         manager.bootstrap().await?;
         Ok(manager)
     }
@@ -402,32 +469,29 @@ impl AdminTrustManager {
             chain: AdminTrustChain::empty(),
             last_update_check: SystemTime::now(),
             check_interval: Duration::from_secs(UPDATE_CHECK_INTERVAL_SECS),
-            bootstrap_status: BootstrapStatus::Success {
-                source: "test".to_string(),
-                version: 0,
-            },
+            bootstrap_status: BootstrapStatus::Success { source: "test".to_string(), version: 0 },
         }
     }
-    
+
     /// Bootstrap from DHT or HTTPS
     async fn bootstrap(&mut self) -> Result<()> {
         // Try DHT first (fast, decentralized)
         self.bootstrap_status = BootstrapStatus::FetchingFromDHT;
-        
+
         // TODO: Implement DHT fetch when node is available
         // if let Ok(chain) = self.fetch_from_dht().await {
         //     self.chain = chain;
-        //     self.bootstrap_status = BootstrapStatus::Success { 
+        //     self.bootstrap_status = BootstrapStatus::Success {
         //         source: "DHT".to_string(),
-        //         version: chain.version 
+        //         version: chain.version
         //     };
         //     return Ok(());
         // }
-        
+
         // Fallback to HTTPS bootstrap
         for url in ADMIN_KEY_BOOTSTRAP_URLS {
             self.bootstrap_status = BootstrapStatus::FetchingFromHTTPS { url: url.to_string() };
-            
+
             match AdminTrustChain::bootstrap_from_https().await {
                 Ok(chain) => {
                     if chain.verify()? {
@@ -436,11 +500,14 @@ impl AdminTrustManager {
                             source: url.to_string(),
                             version: chain.version,
                         };
-                        log::info!("Admin trust chain bootstrapped from HTTPS (version {})", chain.version);
-                        
+                        log::info!(
+                            "Admin trust chain bootstrapped from HTTPS (version {})",
+                            chain.version
+                        );
+
                         // TODO: Cache in DHT for other peers
                         // self.publish_to_dht(&chain).await?;
-                        
+
                         return Ok(());
                     } else {
                         log::warn!("Invalid trust chain from {}", url);
@@ -451,33 +518,29 @@ impl AdminTrustManager {
                 }
             }
         }
-        
-        self.bootstrap_status = BootstrapStatus::Failed {
-            error: "All bootstrap sources failed".to_string(),
-        };
-        
+
+        self.bootstrap_status =
+            BootstrapStatus::Failed { error: "All bootstrap sources failed".to_string() };
+
         Err(anyhow!("Failed to bootstrap admin trust chain"))
     }
-    
+
     /// Create from existing chain (loaded from DHT)
     pub fn from_chain(chain: AdminTrustChain) -> Result<Self> {
         // Verify chain before accepting
         if !chain.verify()? {
             anyhow::bail!("Invalid trust chain");
         }
-        
+
         let version = chain.version;
         Ok(Self {
             chain,
             last_update_check: SystemTime::now(),
-            bootstrap_status: BootstrapStatus::Success {
-                source: "cached".to_string(),
-                version,
-            },
+            bootstrap_status: BootstrapStatus::Success { source: "cached".to_string(), version },
             check_interval: Duration::from_secs(3600),
         })
     }
-    
+
     /// Check if we should query for updates
     pub fn should_update(&self) -> bool {
         SystemTime::now()
@@ -485,23 +548,27 @@ impl AdminTrustManager {
             .unwrap_or(Duration::from_secs(0))
             > self.check_interval
     }
-    
+
     /// Perform update check (DHT first, then HTTPS)
     pub async fn check_for_updates(&mut self) -> Result<bool> {
         if !self.should_update() {
             return Ok(false);
         }
-        
+
         self.last_update_check = SystemTime::now();
-        
+
         // Try DHT first
         // TODO: Implement when DHT node is integrated
-        
+
         // Try HTTPS fallback
         match AdminTrustChain::bootstrap_from_https().await {
             Ok(new_chain) => {
                 if new_chain.version > self.chain.version && new_chain.verify()? {
-                    log::info!("Admin keys updated: v{} -> v{}", self.chain.version, new_chain.version);
+                    log::info!(
+                        "Admin keys updated: v{} -> v{}",
+                        self.chain.version,
+                        new_chain.version
+                    );
                     self.chain = new_chain;
                     return Ok(true);
                 }
@@ -510,10 +577,10 @@ impl AdminTrustManager {
                 log::debug!("Update check failed: {}", e);
             }
         }
-        
+
         Ok(false)
     }
-    
+
     /// Update from DHT record
     pub async fn update_from_dht(&mut self, dht_chain: AdminTrustChain) -> Result<bool> {
         // Verify DHT chain
@@ -521,10 +588,14 @@ impl AdminTrustManager {
             log::warn!("Invalid trust chain from DHT");
             return Ok(false);
         }
-        
+
         // Only accept if newer version
         if dht_chain.version > self.chain.version {
-            log::info!("Updated admin keys from DHT: v{} -> v{}", self.chain.version, dht_chain.version);
+            log::info!(
+                "Updated admin keys from DHT: v{} -> v{}",
+                self.chain.version,
+                dht_chain.version
+            );
             self.chain = dht_chain;
             self.last_update_check = SystemTime::now();
             Ok(true)
@@ -532,57 +603,63 @@ impl AdminTrustManager {
             Ok(false)
         }
     }
-    
+
     /// Serialize chain for DHT storage
     pub fn serialize_for_dht(&self) -> Result<Vec<u8>> {
         Ok(serde_json::to_vec(&self.chain)?)
     }
-    
+
     /// Deserialize chain from DHT
     pub fn deserialize_from_dht(data: &[u8]) -> Result<AdminTrustChain> {
         Ok(serde_json::from_slice(data)?)
     }
-    
+
     /// Check if a key ID is a valid admin
     pub fn is_admin_key(&self, key_id: &str) -> bool {
         self.chain.get_valid_keys().iter().any(|k| k.key_id == key_id)
     }
-    
+
     /// Verify a signature from an admin
-    pub fn verify_admin_signature(&self, key_id: &str, message: &[u8], signature: &[u8]) -> Result<bool> {
+    pub fn verify_admin_signature(
+        &self,
+        key_id: &str,
+        message: &[u8],
+        signature: &[u8],
+    ) -> Result<bool> {
         // Find the key in the current_keys list
-        let admin_key = self.chain.current_keys
+        let admin_key = self
+            .chain
+            .current_keys
             .iter()
             .find(|k| k.key_id == key_id && k.is_valid())
             .ok_or_else(|| anyhow!("Key not found or not valid: {}", key_id))?;
-        
+
         use base64::{Engine, engine::general_purpose};
         let public_key_bytes = general_purpose::STANDARD.decode(&admin_key.public_key)?;
-        use ed25519_dalek::{VerifyingKey, Signature, Verifier};
-        
+        use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+
         // Convert slice to array for VerifyingKey
         let key_array: [u8; 32] = public_key_bytes
             .as_slice()
             .try_into()
             .map_err(|_| anyhow!("Invalid public key length"))?;
-        
+
         let public_key = VerifyingKey::from_bytes(&key_array)
             .map_err(|e| anyhow!("Invalid public key: {}", e))?;
-        
+
         // Convert signature slice to array
-        let sig_array: [u8; 64] = signature
-            .try_into()
-            .map_err(|_| anyhow!("Invalid signature length"))?;
+        let sig_array: [u8; 64] =
+            signature.try_into().map_err(|_| anyhow!("Invalid signature length"))?;
         let sig = Signature::from_bytes(&sig_array);
-        
+
         Ok(public_key.verify(message, &sig).is_ok())
     }
-    
+
     /// Get current trust chain (for publishing to DHT)
     pub fn get_chain(&self) -> &AdminTrustChain {
         &self.chain
     }
-    
+
     /// Get all valid admin key IDs
     pub fn get_admin_key_ids(&self) -> Vec<String> {
         self.chain.get_valid_keys().iter().map(|k| k.key_id.clone()).collect()
@@ -592,7 +669,7 @@ impl AdminTrustManager {
     pub fn get_bootstrap_status(&self) -> &BootstrapStatus {
         &self.bootstrap_status
     }
-    
+
     /// Sign data with an admin key
     /// TODO: Implement real Ed25519 signing once private keys are available
     pub fn sign_data(&self, _data: &[u8]) -> Result<Vec<u8>> {
@@ -600,14 +677,13 @@ impl AdminTrustManager {
         // In production, this would use the actual private key stored securely
         Ok(vec![0u8; 64])
     }
-    
+
     /// Get statistics for TUI
     pub fn get_stats(&self) -> TrustChainStats {
         let valid_keys = self.chain.get_valid_keys();
-        let expired_keys: Vec<_> = self.chain.current_keys.iter()
-            .filter(|k| k.is_expired())
-            .collect();
-        
+        let expired_keys: Vec<_> =
+            self.chain.current_keys.iter().filter(|k| k.is_expired()).collect();
+
         TrustChainStats {
             version: self.chain.version,
             total_keys: self.chain.current_keys.len(),
@@ -635,14 +711,14 @@ pub struct TrustChainStats {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_trust_chain_empty() {
         let chain = AdminTrustChain::empty();
         assert_eq!(chain.current_keys.len(), 0);
         assert_eq!(chain.version, 0);
     }
-    
+
     #[test]
     fn test_key_expiry() {
         let mut key = AdminKey {
@@ -652,17 +728,20 @@ mod tests {
             key_id: "test_id".to_string(),
             description: "Test".to_string(),
         };
-        
+
         assert!(key.is_expired());
-        
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_else(|_| Duration::from_secs(0)).as_secs();
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|_| Duration::from_secs(0))
+            .as_secs();
         key.valid_from = now - 100;
         key.valid_until = now + 100;
-        
+
         assert!(key.is_valid());
         assert!(!key.is_expired());
     }
-    
+
     #[tokio::test]
     async fn test_bootstrap_status() {
         // Test would need mock HTTP server

--- a/apps/service/src/orchestrator/mod.rs
+++ b/apps/service/src/orchestrator/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin_trust;
 /// Orchestrator module - coordinates all components
 ///
 /// The orchestrator is the core coordinator that:
@@ -12,11 +13,8 @@
 /// ## Private Monitor Orchestration
 /// The `private` submodule provides peer-assisted monitoring with encryption
 /// for private services, coordinating helper peers and result synchronization.
-
 pub mod distributed;
 pub mod private;
-pub mod admission;
-pub mod admin_trust;
 pub mod retention;
 
 #[cfg(test)]
@@ -27,7 +25,7 @@ pub use private::PrivateMonitorOrchestrator;
 pub use retention::{RetentionCleanup, RetentionPolicy};
 
 use anyhow::Result;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
@@ -36,7 +34,10 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::config::Config;
-use crate::crypto::{KeyPair, load_or_generate_keypair, sign_result, verify_result, encrypt_result_for_owner};
+use crate::crypto::{
+    KeyPair, decrypt_result_for_owner, encrypt_result_for_owner, load_or_generate_keypair,
+    sign_result, verify_result,
+};
 use crate::database::models::{NetworkStats, Peer};
 use crate::database::{Database, DatabaseImpl, initialize_database};
 use crate::monitoring::checker::CheckType;
@@ -57,12 +58,13 @@ struct HelperAssignmentInfo {
 pub struct Orchestrator {
     #[allow(dead_code)] // Will be used for runtime configuration changes
     config: Arc<Config>,
+    actor_id: String,
     database: Arc<dyn Database>,
     keypair: Arc<KeyPair>,
     executor: Arc<MonitoringExecutor>,
     p2p_network: Arc<P2PNetwork>,
     p2p_event_rx: Option<mpsc::Receiver<crate::p2p::P2PEvent>>,
-    task_handles: Vec<tokio::task::JoinHandle<()>>,
+    task_handles: HashMap<Uuid, tokio::task::JoinHandle<()>>,
     #[allow(dead_code)] // Background task handle kept alive
     retention_cleanup_handle: Option<tokio::task::JoinHandle<()>>,
     #[allow(dead_code)] // Kept alive to manage private monitor helper assignments
@@ -114,9 +116,18 @@ impl Orchestrator {
         )?);
 
         // Create P2P network with configuration
+        // Derive a stable libp2p peer identity from the same Ed25519 secret
+        // used for the app-layer peer ID, so the libp2p peer ID is persistent
+        // across restarts and eliminates the root cause of the dual-identity
+        // and self-healing issues.
         let mut builder = peerup::node::NodeConfig::builder()
             .port_range(config.peerup.port_range)
             .bootstrap_peers(config.peerup.bootstrap_peers.clone());
+
+        {
+            let mut secret = keypair.signing_key.to_bytes();
+            builder = builder.identity_from_ed25519_secret(&mut secret)?;
+        }
 
         // Conditionally enable/disable features
         if config.peerup.enable_mdns {
@@ -169,17 +180,20 @@ impl Orchestrator {
 
         Ok(Self {
             config,
+            actor_id: peer_id,
             database,
             keypair,
             executor,
             p2p_network: Arc::new(p2p_network),
             p2p_event_rx,
-            task_handles: Vec::new(),
+            task_handles: HashMap::new(),
             retention_cleanup_handle: Some(retention_handle),
-            private_orchestrator: None, // Will be set in run()
+            private_orchestrator: None,     // Will be set in run()
             distributed_orchestrator: None, // Will be set in run()
             helper_assignments: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
-            rate_limiter: Arc::new(tokio::sync::RwLock::new(private::PrivateMonitorRateLimiter::new())),
+            rate_limiter: Arc::new(tokio::sync::RwLock::new(
+                private::PrivateMonitorRateLimiter::new(),
+            )),
         })
     }
 
@@ -193,7 +207,7 @@ impl Orchestrator {
         let (result_tx, mut result_rx) = mpsc::channel::<CheckResult>(100);
 
         // Create scheduler (mutable for dynamic monitor reloading)
-        let mut scheduler = MonitoringScheduler::new(self.executor.clone(), result_tx.clone());
+        let scheduler = MonitoringScheduler::new(self.executor.clone(), result_tx.clone());
 
         // Load monitors from database and schedule them
         info!("Loading monitors from database...");
@@ -201,16 +215,24 @@ impl Orchestrator {
         info!("Found {} enabled monitors", monitors.len());
 
         // Create monitor visibility map to check before sharing results (mutable for dynamic updates)
-        let mut monitor_visibility: HashMap<Uuid, crate::database::models::MonitorVisibility> = HashMap::new();
+        let mut monitor_visibility: HashMap<Uuid, crate::database::models::MonitorVisibility> =
+            HashMap::new();
+        // Map: normalised target URL → local monitor UUID, for public monitors.
+        // Used to remap incoming gossipsub results from other peers (which carry
+        // their own UUIDs) to our local monitor UUID so the frontend can
+        // aggregate results and peer counts correctly.
+        let mut target_to_local_uuid: HashMap<String, Uuid> = HashMap::new();
         for m in &monitors {
             monitor_visibility.insert(m.uuid, m.visibility.clone());
+            if m.is_public() {
+                target_to_local_uuid.insert(m.target.trim_end_matches('/').to_lowercase(), m.uuid);
+            }
         }
 
         // Run Owner Sync if enabled (attempts to sync encrypted private results from DHT)
         // This is optional and will log warnings on failure without stopping startup
         if self.p2p_network.is_enabled() {
             info!("Attempting Owner Sync from DHT...");
-            let owner_secret_key = self.keypair.x25519_secret_bytes();
             let owner_pubkey = self.keypair.x25519_public_key();
             let private_orchestrator = PrivateMonitorOrchestrator::new(
                 self.database.clone(),
@@ -224,10 +246,8 @@ impl Orchestrator {
                 warn!("Failed to initialize private monitor orchestrator: {}", e);
             }
 
-            match private_orchestrator.sync_owner_results_from_dht(&owner_secret_key).await {
-                Ok(()) => info!("Owner sync completed successfully"),
-                Err(e) => warn!("Owner sync failed (this is normal on first run): {}", e),
-            }
+            // NOTE: DHT sync is deferred to the first PeerConnected event so that
+            // routing peers are available before we issue Kademlia queries.
 
             // Keep the orchestrator alive for dynamic helper assignment
             self.private_orchestrator = Some(Arc::new(private_orchestrator));
@@ -247,31 +267,40 @@ impl Orchestrator {
             info!("Skipping Owner Sync - P2P network disabled");
         }
 
-        // Convert database monitors to scheduler configs
-        let monitor_configs: Vec<MonitorConfig> = monitors
-            .into_iter()
-            .map(|m| {
-                let check_type = match m.check_type.as_str() {
-                    "http" => CheckType::Http,
-                    "https" => CheckType::Https,
-                    "tcp" => CheckType::Tcp,
-                    "icmp" => CheckType::Icmp,
-                    _ => CheckType::Http,
-                };
-
-                MonitorConfig {
-                    id: m.uuid,
-                    target: m.target,
-                    check_type,
-                    interval_seconds: m.interval_seconds,
-                    enabled: m.enabled,
-                }
-            })
-            .collect();
+        // Convert database monitors to scheduler configs (with staggered phase offsets)
+        let my_peer_id = self.keypair.public_key_hex();
+        let mut monitor_configs: Vec<MonitorConfig> = Vec::with_capacity(monitors.len());
+        for m in monitors {
+            let check_type = match m.check_type.as_str() {
+                "http" => CheckType::Http,
+                "https" => CheckType::Https,
+                "tcp" => CheckType::Tcp,
+                "icmp" => CheckType::Icmp,
+                _ => CheckType::Http,
+            };
+            let phase_offset_secs = if let (Some(orch), Some(domain)) =
+                (&self.distributed_orchestrator, m.public_domain.as_deref())
+            {
+                orch.get_peer_phase_offset(domain, &my_peer_id).await
+            } else {
+                0
+            };
+            monitor_configs.push(MonitorConfig {
+                id: m.uuid,
+                target: m.target,
+                check_type,
+                interval_seconds: m.interval_seconds,
+                enabled: m.enabled,
+                phase_offset_secs,
+            });
+        }
 
         // Schedule all monitors
         info!("Scheduling monitors...");
-        self.task_handles = scheduler.schedule_monitors(monitor_configs);
+        self.task_handles = monitor_configs
+            .into_iter()
+            .map(|c| (c.id, scheduler.schedule_monitor(c)))
+            .collect();
 
         // Process results in a loop
         info!("Orchestrator started successfully - processing monitoring results");
@@ -292,13 +321,43 @@ impl Orchestrator {
         let mut last_helper_maintenance = Instant::now();
         let helper_maintenance_interval = Duration::from_secs(60); // Check helper health every minute
 
+        // Track last reconnect attempt (for bootstrap peer re-dial).
+        // On startup we retry with short delays so helper assignment doesn't
+        // have to wait 30 s before a first peer is discovered.
+        // Schedule: 5 s → 10 s → 20 s → 30 s (steady-state).
+        let reconnect_interval = Duration::from_secs(30);
+        let mut startup_reconnect_delays: VecDeque<Duration> = VecDeque::from([
+            Duration::from_secs(5),
+            Duration::from_secs(10),
+            Duration::from_secs(20),
+        ]);
+        let mut current_reconnect_delay =
+            startup_reconnect_delays.pop_front().unwrap_or(reconnect_interval);
+        let mut last_reconnect_attempt = Instant::now();
+        // Periodic presence re-announce: even without new connections, re-broadcast
+        // so any peer that came up while we were already running can discover us.
+        let mut last_periodic_announce = Instant::now();
+        let periodic_announce_interval = Duration::from_secs(300); // every 5 min
+
         // P2P/network stats tracking
         let mut connected_peers: HashSet<String> = HashSet::new();
         let mut total_peers_seen: HashSet<String> = HashSet::new();
+        // Only peers that have announced themselves as uppe-service nodes are eligible
+        // as helper candidates.  Plain peerup routing/relay nodes are excluded.
+        let mut uppe_service_peers: HashSet<String> = HashSet::new();
         let mut checks_performed: i64 = 0;
         let mut checks_received: i64 = 0;
         let mut last_stats_persist = Instant::now();
         let stats_persist_interval = Duration::from_secs(5);
+
+        // Deferred DHT sync — triggered once on first peer connection.
+        let mut dht_sync_done = false;
+
+        // Name consensus: domain → { name → vote_count }
+        let mut domain_name_votes: std::collections::HashMap<
+            String,
+            std::collections::HashMap<String, usize>,
+        > = std::collections::HashMap::new();
 
         // Use the P2P event receiver that was returned from start()
         let mut p2p_event_rx = self.p2p_event_rx.take();
@@ -326,10 +385,10 @@ impl Orchestrator {
                         // This is a helper assignment - encrypt and send the result back to the owner
                         let assignment_clone = assignment.clone();
                         drop(assignments); // Release the lock
-                        
-                        info!("Encrypting helper result for monitor {} and owner {}", 
+
+                        info!("Encrypting helper result for monitor {} and owner {}",
                               signed_result.monitor_id, assignment_clone.owner_peer_id);
-                        
+
                         match encrypt_result_for_owner(
                             &signed_result,
                             &assignment_clone.owner_public_key,
@@ -357,6 +416,16 @@ impl Orchestrator {
                     // Save to database
                     if let Err(e) = self.database.save_result(&signed_result).await {
                         error!("Failed to save result to database: {}", e);
+                    } else if let Err(e) = crate::audit::record_local_result_event(
+                        self.database.as_ref(),
+                        self.keypair.as_ref(),
+                        &self.actor_id,
+                        "local_scheduler",
+                        &signed_result,
+                    )
+                    .await
+                    {
+                        warn!("Failed to record local result audit event: {}", e);
                     }
 
                     // Update stats for locally performed check
@@ -421,6 +490,30 @@ impl Orchestrator {
 
                             total_peers_seen.insert(peer_id.clone());
 
+                            // A peer delivering gossipsub results is reachable AND running
+                            // uppe-service.  Populate the tracking sets in case
+                            // ConnectionEstablished / NodeAnnounced events were missed
+                            // (race at startup, or the peer was already connected).
+                            {
+                                let newly_connected = connected_peers.insert(peer_id.clone());
+                                let newly_uppe = uppe_service_peers.insert(peer_id.clone());
+                                if newly_connected || newly_uppe {
+                                    if let Some(private_orch) = &self.private_orchestrator {
+                                        if newly_connected {
+                                            private_orch.handle_peer_connected(peer_id.clone()).await;
+                                        }
+                                        private_orch.update_uppe_service_peers(uppe_service_peers.clone()).await;
+                                        if let Err(e) = private_orch.retry_unhelped_monitors().await {
+                                            tracing::debug!("retry_unhelped from ResultReceived: {}", e);
+                                        }
+                                    }
+                                    tracing::debug!(
+                                        peer = %peer_id,
+                                        "Discovered uppe-service peer via gossipsub result"
+                                    );
+                                }
+                            }
+
                             // Convert P2P result to database model
                             if let Some(mut db_result) = crate::database::models::PeerResult::from_p2p_result(&result) {
                                 // Verify signature if public key is available
@@ -479,14 +572,129 @@ impl Orchestrator {
                                 if let Err(e) = self.database.save_peer_result(&db_result).await {
                                     error!("Failed to save peer result: {}", e);
                                 } else {
+                                    match crate::audit::record_peer_result_event(
+                                        self.database.as_ref(),
+                                        self.keypair.as_ref(),
+                                        &self.actor_id,
+                                        "p2p_gossipsub",
+                                        &db_result,
+                                    )
+                                    .await
+                                    {
+                                        Ok(event_id) => {
+                                            let reason = if result.public_key.is_none() {
+                                                Some("missing public key")
+                                            } else if verified {
+                                                Some("signature valid")
+                                            } else {
+                                                Some("signature invalid")
+                                            };
+                                            if let Err(e) = crate::audit::record_result_verification_attestation(
+                                                self.database.as_ref(),
+                                                self.keypair.as_ref(),
+                                                &self.actor_id,
+                                                event_id,
+                                                verified,
+                                                reason,
+                                            )
+                                            .await
+                                            {
+                                                warn!("Failed to record peer result verification attestation: {}", e);
+                                            }
+                                        }
+                                        Err(e) => {
+                                            warn!("Failed to record peer result audit event: {}", e);
+                                        }
+                                    }
                                     let status = if verified { "verified" } else { "unverified" };
                                     debug!("Successfully saved {} peer result from {}", status, peer_id);
+                                }
+
+                                // For public monitors, also write to monitor_results so the
+                                // Go API server can serve the result with the correct peer ID.
+                                if let Some(vis) = monitor_visibility.get(&result.result.monitor_id) {
+                                    use crate::database::models::MonitorVisibility;
+                                    if matches!(vis, MonitorVisibility::Public) {
+                                        if let Err(e) = self.database.save_result(&result.result).await {
+                                            warn!("Failed to mirror public peer result to monitor_results: {}", e);
+                                        } else if let Err(e) = crate::audit::record_local_result_event(
+                                            self.database.as_ref(),
+                                            self.keypair.as_ref(),
+                                            &self.actor_id,
+                                            "peer_public_mirror",
+                                            &result.result,
+                                        )
+                                        .await
+                                        {
+                                            warn!("Failed to record mirrored peer result audit event: {}", e);
+                                        }
+                                    }
+                                } else {
+                                    // Result UUID is unknown locally — try to match by target URL
+                                    // (other peers monitoring the same service use their own UUIDs).
+                                    let norm_target = result.result.target.trim_end_matches('/').to_lowercase();
+                                    if let Some(&local_uuid) = target_to_local_uuid.get(&norm_target) {
+                                        // Remap result to our local monitor UUID before saving
+                                        let mut remapped = result.result.clone();
+                                        remapped.monitor_id = local_uuid;
+                                        if let Err(e) = self.database.save_result(&remapped).await {
+                                            warn!("Failed to save remapped peer result for target {}: {}", norm_target, e);
+                                        } else if let Err(e) = crate::audit::record_local_result_event(
+                                            self.database.as_ref(),
+                                            self.keypair.as_ref(),
+                                            &self.actor_id,
+                                            "peer_public_remapped",
+                                            &remapped,
+                                        )
+                                        .await
+                                        {
+                                            warn!("Failed to record remapped peer result audit event: {}", e);
+                                        } else {
+                                            debug!("Remapped peer result for {} to local UUID {}", norm_target, local_uuid);
+                                        }
+                                    }
                                 }
 
                                 // Update stats for received results
                                 checks_received += 1;
                             } else {
                                 warn!("Received peer result without signature from {}", peer_id);
+                            }
+                        }
+                        P2PEvent::NodeAnnounced { libp2p_peer_id, app_peer_id: _ } => {
+                            let is_new = !uppe_service_peers.contains(&libp2p_peer_id);
+                            if is_new {
+                                info!(peer = %libp2p_peer_id, "uppe-service peer announced");
+                                uppe_service_peers.insert(libp2p_peer_id.clone());
+                            }
+                            // Update the private orchestrator's allowed helper set
+                            if let Some(private_orch) = &self.private_orchestrator {
+                                private_orch.update_uppe_service_peers(uppe_service_peers.clone()).await;
+                                // Retry any monitors that previously had no helpers —
+                                // a newly announced peer may now be eligible.
+                                if is_new {
+                                    if let Err(e) = private_orch.retry_unhelped_monitors().await {
+                                        tracing::warn!("retry_unhelped after announce failed: {}", e);
+                                    }
+                                }
+                            }
+                            // Broadcast all our public monitor groups so this new peer can
+                            // discover and auto-join them.
+                            if is_new {
+                                if let Some(dist_orch) = &self.distributed_orchestrator {
+                                    if let Err(e) = dist_orch.broadcast_all_for_discovery().await {
+                                        tracing::debug!("broadcast_all_for_discovery failed: {}", e);
+                                    }
+                                }
+                            }
+                            // Mutual re-announce: respond with our own presence so the announcing
+                            // peer learns we are also a uppe-service node.  Gossipsub does not
+                            // replay history — the new peer subscribed to /uppe/announce/v1 AFTER
+                            // we last published, so they never received our announcement.
+                            if is_new && p2p_network.is_enabled() {
+                                let _ = p2p_network.send_command(
+                                    crate::p2p::messages::P2PCommand::AnnouncePresence
+                                ).await;
                             }
                         }
                         P2PEvent::PeerConnected(peer_id) => {
@@ -505,36 +713,93 @@ impl Orchestrator {
                             // Update private orchestrator with new peer
                             if let Some(private_orch) = &self.private_orchestrator {
                                 private_orch.handle_peer_connected(peer_id.clone()).await;
+
+                                // Clear private monitors from the "already assigned" set
+                                // if they have no active/pending helpers.
+                                let active = private_orch.get_assigned_monitor_uuids().await;
+                                assigned_private_monitors.retain(|uuid| active.contains(uuid));
+
+                                // Immediately retry any unhelped monitors now that a new peer
+                                // is online — don't wait for the 30-second reload tick.
+                                if let Err(e) = private_orch.retry_unhelped_monitors().await {
+                                    tracing::warn!("retry_unhelped after peer connect failed: {}", e);
+                                }
+                            }
+
+                            // Re-broadcast our own announcement so this peer learns we are uppe-service
+                            if p2p_network.is_enabled() {
+                                let _ = p2p_network.send_command(
+                                    crate::p2p::messages::P2PCommand::AnnouncePresence
+                                ).await;
                             }
 
                             let peer_model = Peer::new_online(peer_id.clone(), now);
                             if let Err(e) = self.database.upsert_peer(&peer_model).await {
                                 warn!("Failed to upsert peer {}: {}", peer_id, e);
                             }
+
+                            // First peer connection: trigger deferred DHT result sync.
+                            // We spawn it so the event loop stays responsive.
+                            if !dht_sync_done {
+                                dht_sync_done = true;
+                                if let Some(private_orch) = &self.private_orchestrator {
+                                    let orch = Arc::clone(private_orch);
+                                    let key = self.keypair.x25519_secret_bytes();
+                                    tokio::spawn(async move {
+                                        // Wait a moment for DHT routing to stabilise
+                                        tokio::time::sleep(Duration::from_secs(4)).await;
+                                        match orch.sync_owner_results_from_dht(&key).await {
+                                            Ok(()) => info!("Deferred DHT sync completed"),
+                                            Err(e) => warn!("Deferred DHT sync failed: {}", e),
+                                        }
+                                    });
+                                }
+                            }
                         }
                         P2PEvent::PeerDisconnected(peer_id) => {
                             info!(target: "uppe::audit", peer = %peer_id, "Peer disconnected");
 
                             connected_peers.remove(&peer_id);
+                            uppe_service_peers.remove(&peer_id);
+                            // Re-arm DHT sync so the next reconnect after a full
+                            // network partition triggers encrypted-result recovery.
+                            if connected_peers.is_empty() {
+                                dht_sync_done = false;
+                            }
                             #[allow(unused_must_use)]
                             {
                                 crate::tui::bus::publish_peers(connected_peers.iter().cloned().collect(), SystemTime::now());
                             }
-                            
+
                             // Update private orchestrator with disconnected peer
                             if let Some(private_orch) = &self.private_orchestrator {
                                 private_orch.handle_peer_disconnected(&peer_id).await;
                             }
-                            
+
                             if let Err(e) = self.database.mark_peer_offline(&peer_id, SystemTime::now()).await {
                                 warn!("Failed to mark peer offline {}: {}", peer_id, e);
+                            }
+
+                            // Remove disconnected peer from all public monitor groups
+                            if let Some(dist_orch) = &self.distributed_orchestrator {
+                                for group in dist_orch.get_all_groups().await {
+                                    if group.participating_peers.contains(&peer_id) {
+                                        if let Err(e) = dist_orch.handle_peer_leave(group.domain.clone(), peer_id.clone()).await {
+                                            tracing::debug!("handle_peer_leave {}/{}: {}", group.domain, peer_id, e);
+                                        }
+                                    }
+                                }
                             }
                         }
                         P2PEvent::Started { peer_id } => {
                             info!("P2P network started with peer ID: {}", peer_id);
                         }
                         P2PEvent::Error(err) => {
-                            error!("P2P error: {}", err);
+                            if err.contains("Duplicate") || err.contains("NoPeersSubscribedToTopic") {
+                                tracing::debug!("P2P publish skipped (expected): {}", err);
+                            } else {
+                                error!("P2P error: {}", err);
+                            }
                         }
                         P2PEvent::HelperAssignmentRequested { from_peer, request } => {
                             info!(
@@ -547,13 +812,14 @@ impl Orchestrator {
                                 // Check if we have capacity for more assignments
                                 let current_assignments = self.helper_assignments.read().await.len();
                                 let max_assignments = 10; // Configurable limit
-                                
+
                                 if current_assignments >= max_assignments {
                                     warn!("Rejecting helper assignment - at capacity ({}/{})", current_assignments, max_assignments);
 
                                     let rejection = crate::p2p::messages::HelperAssignmentResponse::Rejected {
                                         monitor_uuid: request.monitor_uuid.clone(),
                                         reason: format!("Helper at capacity ({}/{})", current_assignments, max_assignments),
+                                        owner_libp2p_peer_id: request.owner_libp2p_peer_id.clone(),
                                     };
 
                                     if let Err(e) = p2p_network.send_command(
@@ -577,6 +843,7 @@ impl Orchestrator {
                                         let rejection = crate::p2p::messages::HelperAssignmentResponse::Rejected {
                                             monitor_uuid: request.monitor_uuid.clone(),
                                             reason: "Owner rate limit exceeded".to_string(),
+                                            owner_libp2p_peer_id: request.owner_libp2p_peer_id.clone(),
                                         };
                                         if let Err(e) = p2p_network.send_command(
                                             crate::p2p::messages::P2PCommand::SendHelperResponse(rejection)
@@ -593,7 +860,7 @@ impl Orchestrator {
                                     owner_peer_id: request.owner_peer_id.clone(),
                                     owner_public_key: request.owner_public_key,
                                 };
-                                
+
                                 {
                                     let mut assignments = self.helper_assignments.write().await;
                                     assignments.insert(monitor_id, assignment_info);
@@ -614,11 +881,12 @@ impl Orchestrator {
                                     check_type,
                                     interval_seconds: request.interval_seconds,
                                     enabled: true,
+                                    phase_offset_secs: request.check_offset_seconds,
                                 };
 
                                 // Schedule this helper monitor
                                 let handle = scheduler.schedule_monitor(monitor_config);
-                                self.task_handles.push(handle);
+                                self.task_handles.insert(monitor_id, handle);
 
                                 info!(
                                     "Successfully scheduled helper monitoring for {} (owner: {})",
@@ -629,6 +897,7 @@ impl Orchestrator {
                                 let acceptance = crate::p2p::messages::HelperAssignmentResponse::Accepted {
                                     monitor_uuid: request.monitor_uuid.clone(),
                                     helper_peer_id: self.keypair.public_key_hex(),
+                                    owner_libp2p_peer_id: request.owner_libp2p_peer_id.clone(),
                                 };
                                 if let Err(e) = p2p_network.send_command(
                                     crate::p2p::messages::P2PCommand::SendHelperResponse(acceptance)
@@ -647,16 +916,70 @@ impl Orchestrator {
 
                             // Parse the monitor UUID
                             if let Ok(monitor_id) = uuid::Uuid::parse_str(&encrypted_result.monitor_uuid) {
+                                // If this node is a helper for this monitor (not the owner),
+                                // the gossipsub message was looped back to us — ignore it.
+                                let we_are_helper = self.helper_assignments.read().await.contains_key(&monitor_id);
+                                if we_are_helper {
+                                    debug!(
+                                        monitor = %monitor_id,
+                                        "Ignoring looped-back encrypted result (we are the helper, not the owner)"
+                                    );
+                                    // skip — don't try to decrypt with our own key
+                                }
+                                else {
                                 // Update helper last_seen if we're the owner
                                 if let Some(private_orch) = &self.private_orchestrator {
                                     private_orch.handle_helper_result(&from_peer).await;
                                 }
-                                
-                                debug!(
-                                    "Encrypted result from helper {} for owner {} (monitor {})",
-                                    from_peer, encrypted_result.owner_peer_id, monitor_id
-                                );
-                                checks_received += 1;
+
+                                // Decrypt and save the result to our local database
+                                let owner_secret_key = self.keypair.x25519_secret_bytes();
+                                match decrypt_result_for_owner::<CheckResult>(
+                                    &encrypted_result,
+                                    &owner_secret_key,
+                                ) {
+                                    Ok(decrypted) => {
+                                        if let Err(e) = self.database.save_result(&decrypted).await {
+                                            warn!(
+                                                monitor = %monitor_id,
+                                                from = %from_peer,
+                                                "Failed to save decrypted private result: {}",
+                                                e
+                                            );
+                                        } else {
+                                            if let Err(e) = crate::audit::record_local_result_event(
+                                                self.database.as_ref(),
+                                                self.keypair.as_ref(),
+                                                &self.actor_id,
+                                                "helper_decrypted_result",
+                                                &decrypted,
+                                            )
+                                            .await
+                                            {
+                                                warn!(
+                                                    monitor = %monitor_id,
+                                                    "Failed to record decrypted private result audit event: {}",
+                                                    e
+                                                );
+                                            }
+                                            info!(
+                                                monitor = %monitor_id,
+                                                helper = %from_peer,
+                                                "Saved decrypted private result"
+                                            );
+                                            checks_received += 1;
+                                        }
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            monitor = %monitor_id,
+                                            from = %from_peer,
+                                            "Failed to decrypt helper result: {}",
+                                            e
+                                        );
+                                    }
+                                }
+                                } // end else (we are not the helper)
                             } else {
                                 warn!("Invalid monitor UUID in encrypted result: {}", encrypted_result.monitor_uuid);
                             }
@@ -686,21 +1009,216 @@ impl Orchestrator {
                                 "Received helper assignment response from peer {}",
                                 from_peer
                             );
-                            
+
                             // Route to private orchestrator
                             if let Some(private_orch) = &self.private_orchestrator {
                                 use crate::p2p::messages::HelperAssignmentResponse;
                                 match *response {
-                                    HelperAssignmentResponse::Accepted { ref monitor_uuid, ref helper_peer_id } => {
-                                        if let Err(e) = private_orch.handle_helper_accepted(monitor_uuid, helper_peer_id).await {
+                                    HelperAssignmentResponse::Accepted { ref monitor_uuid, .. } => {
+                                        // Use the libp2p peer ID (from_peer) rather than the
+                                        // app peer ID from the response payload.  All other
+                                        // helper tracking (uppe_service_peers, assignments,
+                                        // handle_helper_result) uses libp2p IDs, so we must
+                                        // be consistent here to avoid stale-helper false alarms.
+                                        if let Err(e) = private_orch.handle_helper_accepted(monitor_uuid, &from_peer).await {
                                             warn!("Failed to handle helper acceptance: {}", e);
                                         }
                                     }
-                                    HelperAssignmentResponse::Rejected { ref monitor_uuid, ref reason } => {
+                                    HelperAssignmentResponse::Rejected { ref monitor_uuid, ref reason, .. } => {
                                         if let Err(e) = private_orch.handle_helper_rejected(monitor_uuid, &from_peer, reason).await {
                                             warn!("Failed to handle helper rejection: {}", e);
                                         }
                                     }
+                                }
+                            }
+                        }
+                        P2PEvent::PublicMonitorAnnounced {
+                            domain,
+                            display_name,
+                            creator_peer_id,
+                            target,
+                            check_type,
+                            interval_seconds,
+                        } => {
+                            // Skip announcements originating from ourselves so we don't
+                            // accidentally count our own broadcast as a name-consensus vote
+                            // or try to re-join a group we already own.
+                            let our_peer_id = self.keypair.public_key_hex();
+                            if creator_peer_id == our_peer_id {
+                                // nothing to do — we already have this monitor
+                            } else {
+
+                            // --- Name consensus: accumulate votes for this domain's display name ---
+                            {
+                                let votes = domain_name_votes
+                                    .entry(domain.clone())
+                                    .or_default();
+                                *votes.entry(display_name.clone()).or_insert(0) += 1;
+
+                                // Find the name with the most votes
+                                if let Some((leading_name, &leading_count)) =
+                                    votes.iter().max_by_key(|(_, c)| *c)
+                                {
+                                    // Only promote a new name when it has a clear majority
+                                    // (≥ 2 votes ahead of any runner-up, and at least 2 votes)
+                                    let runner_up = votes
+                                        .iter()
+                                        .filter(|(n, _)| *n != leading_name)
+                                        .map(|(_, c)| *c)
+                                        .max()
+                                        .unwrap_or(0);
+                                    if leading_count >= 2 && leading_count > runner_up + 1 {
+                                        // Update stored display name if it differs
+                                        let monitor_uuid = crate::database::models::Monitor::uuid_for_public_domain(&domain);
+                                        if let Ok(Some(mut existing)) =
+                                            self.database.get_monitor_by_uuid(monitor_uuid).await
+                                        {
+                                            if existing.public_display_name.as_deref() != Some(leading_name.as_str()) {
+                                                info!(
+                                                    domain = %domain,
+                                                    old_name = ?existing.public_display_name,
+                                                    new_name = %leading_name,
+                                                    votes = leading_count,
+                                                    "Updating public monitor display name via consensus"
+                                                );
+                                                existing.public_display_name = Some(leading_name.clone());
+                                                if let Err(e) = self.database.save_monitor(&existing).await {
+                                                    warn!("Failed to update consensus display name for {}: {}", domain, e);
+                                                } else if let Err(e) = crate::audit::record_monitor_event(
+                                                    self.database.as_ref(),
+                                                    self.keypair.as_ref(),
+                                                    &self.actor_id,
+                                                    "updated",
+                                                    &existing,
+                                                )
+                                                .await
+                                                {
+                                                    warn!("Failed to record consensus monitor update audit event: {}", e);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            if let Some(dist_orch) = &self.distributed_orchestrator {
+                                // Record announcing peer in the group + cast their schedule vote
+                                if let Err(e) = dist_orch.handle_peer_join(domain.clone(), creator_peer_id.clone()).await {
+                                    tracing::debug!("handle_peer_join {}/{}: {}", domain, creator_peer_id, e);
+                                }
+                                let vote = peerup::distributed::OrchestrationVote {
+                                    domain: domain.clone(),
+                                    schedule: peerup::distributed::OrchestrationSchedule {
+                                        interval_seconds,
+                                        assignments: Vec::new(),
+                                    },
+                                    voter_peer_id: creator_peer_id.clone(),
+                                    signature: String::new(),
+                                    public_key: None,
+                                    timestamp: chrono::Utc::now().timestamp(),
+                                };
+                                if let Err(e) = dist_orch.handle_vote(vote).await {
+                                    tracing::debug!("handle_vote {}: {}", domain, e);
+                                }
+
+                                // Only join if we don't already track this domain group
+                                if dist_orch.get_group(&domain).await.is_none() {
+                                    info!(
+                                        domain = %domain,
+                                        target = %target,
+                                        creator = %creator_peer_id,
+                                        "Auto-joining public monitor group"
+                                    );
+
+                                    // Build a new public monitor record so this node
+                                    // can independently check the target.
+                                    let mut monitor = crate::database::models::Monitor::new_public(
+                                        format!("{} (community)", display_name),
+                                        target.clone(),
+                                        check_type.clone(),
+                                        domain.clone(),
+                                        display_name.clone(),
+                                    );
+                                    monitor.interval_seconds = interval_seconds;
+
+                                    match self.database.save_monitor(&monitor).await {
+                                        Ok(_) => {
+                                            if let Err(e) = crate::audit::record_monitor_event(
+                                                self.database.as_ref(),
+                                                self.keypair.as_ref(),
+                                                &self.actor_id,
+                                                "created",
+                                                &monitor,
+                                            )
+                                            .await
+                                            {
+                                                warn!("Failed to record auto-joined monitor audit event: {}", e);
+                                            }
+                                            if let Err(e) = dist_orch.handle_new_monitor(&monitor).await {
+                                                warn!(
+                                                    domain = %domain,
+                                                    "Failed to join public monitor group: {}",
+                                                    e
+                                                );
+                                            } else {
+                                                info!(
+                                                    domain = %domain,
+                                                    target = %target,
+                                                    "Joined public monitor group — will be scheduled in next reload tick"
+                                                );
+                                                // Trigger an immediate monitor reload so the
+                                                // new entry is scheduled without waiting 30 s.
+                                                last_monitor_reload =
+                                                    Instant::now()
+                                                        .checked_sub(monitor_reload_interval)
+                                                        .unwrap_or_else(Instant::now);
+                                            }
+                                        }
+                                        Err(e) => {
+                                            warn!(
+                                                domain = %domain,
+                                                "Failed to save auto-joined public monitor: {}",
+                                                e
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                            } // end else (creator_peer_id != our_peer_id)
+                        }
+                        P2PEvent::PublicMonitorGroupMessage { _from_peer: _, domain, message } => {
+                            if let Some(dist_orch) = &self.distributed_orchestrator {
+                                use peerup::distributed::PublicMonitorMessage;
+                                match *message {
+                                    PublicMonitorMessage::Join { peer_id, .. } => {
+                                        if let Err(e) = dist_orch.handle_peer_join(domain.clone(), peer_id.clone()).await {
+                                            tracing::debug!("handle_peer_join {}/{}: {}", domain, peer_id, e);
+                                        }
+                                    }
+                                    PublicMonitorMessage::Leave { peer_id, .. } => {
+                                        if let Err(e) = dist_orch.handle_peer_leave(domain.clone(), peer_id.clone()).await {
+                                            tracing::debug!("handle_peer_leave {}/{}: {}", domain, peer_id, e);
+                                        }
+                                    }
+                                    PublicMonitorMessage::ScheduleUpdate { schedule, .. } => {
+                                        // Construct a vote from the received schedule.
+                                        // voter_peer_id is unknown here (ScheduleUpdate
+                                        // doesn't carry it); the from_peer field is the
+                                        // sender's libp2p ID, not their app peer ID, so
+                                        // we leave voter_peer_id empty for now.
+                                        let vote = peerup::distributed::OrchestrationVote {
+                                            domain: domain.clone(),
+                                            schedule,
+                                            voter_peer_id: String::new(),
+                                            signature: String::new(),
+                                            public_key: None,
+                                            timestamp: chrono::Utc::now().timestamp(),
+                                        };
+                                        if let Err(e) = dist_orch.handle_vote(vote).await {
+                                            tracing::debug!("handle_vote {}: {}", domain, e);
+                                        }
+                                    }
+                                    _ => {} // Announce covered by PublicMonitorAnnounced on discovery topic
                                 }
                             }
                         }
@@ -746,35 +1264,48 @@ impl Orchestrator {
                 _ = tokio::time::sleep_until(tokio::time::Instant::from_std(last_monitor_reload + monitor_reload_interval)) => {
                     if last_monitor_reload.elapsed() >= monitor_reload_interval {
                         debug!("Checking for new or updated monitors...");
-                        
+
                         match self.database.get_enabled_monitors().await {
                             Ok(current_monitors) => {
                                 // Build new monitor configs
-                                let new_monitor_configs: Vec<MonitorConfig> = current_monitors
-                                    .iter()
-                                    .map(|m| {
-                                        let check_type = match m.check_type.as_str() {
-                                            "http" => CheckType::Http,
-                                            "https" => CheckType::Https,
-                                            "tcp" => CheckType::Tcp,
-                                            "icmp" => CheckType::Icmp,
-                                            _ => CheckType::Http,
-                                        };
-
-                                        MonitorConfig {
-                                            id: m.uuid,
-                                            target: m.target.clone(),
-                                            check_type,
-                                            interval_seconds: m.interval_seconds,
-                                            enabled: m.enabled,
-                                        }
-                                    })
-                                    .collect();
+                                let my_peer_id = self.keypair.public_key_hex();
+                                let mut new_monitor_configs: Vec<MonitorConfig> = Vec::with_capacity(current_monitors.len());
+                                for m in &current_monitors {
+                                    let check_type = match m.check_type.as_str() {
+                                        "http" => CheckType::Http,
+                                        "https" => CheckType::Https,
+                                        "tcp" => CheckType::Tcp,
+                                        "icmp" => CheckType::Icmp,
+                                        _ => CheckType::Http,
+                                    };
+                                    let phase_offset_secs = if let (Some(orch), Some(domain)) =
+                                        (&self.distributed_orchestrator, m.public_domain.as_deref())
+                                    {
+                                        orch.get_peer_phase_offset(domain, &my_peer_id).await
+                                    } else {
+                                        0
+                                    };
+                                    new_monitor_configs.push(MonitorConfig {
+                                        id: m.uuid,
+                                        target: m.target.clone(),
+                                        check_type,
+                                        interval_seconds: m.interval_seconds,
+                                        enabled: m.enabled,
+                                        phase_offset_secs,
+                                    });
+                                }
 
                                 // Update monitor visibility map
                                 monitor_visibility.clear();
+                                target_to_local_uuid.clear();
                                 for m in &current_monitors {
                                     monitor_visibility.insert(m.uuid, m.visibility.clone());
+                                    if m.is_public() {
+                                        target_to_local_uuid.insert(
+                                            m.target.trim_end_matches('/').to_lowercase(),
+                                            m.uuid,
+                                        );
+                                    }
                                 }
 
                                 // Check for new private monitors and assign helpers
@@ -783,7 +1314,7 @@ impl Orchestrator {
                                         .iter()
                                         .filter(|m| m.is_private())
                                         .collect();
-                                    
+
                                     for monitor in private_monitors {
                                         // Only assign helpers if this is a NEW private monitor
                                         // Don't reassign on every reload - that causes unnecessary churn
@@ -805,14 +1336,49 @@ impl Orchestrator {
                                 let current_uuids: HashSet<Uuid> = current_monitors.iter().map(|m| m.uuid).collect();
                                 assigned_private_monitors.retain(|uuid| current_uuids.contains(uuid));
 
-                                // Cancel old tasks and reschedule all monitors
-                                for handle in self.task_handles.drain(..) {
-                                    handle.abort();
+                                // Only start tasks for new monitors; abort tasks for removed ones.
+                                // Existing running tasks are left untouched so their timers aren't reset.
+                                let new_config_map: HashMap<Uuid, MonitorConfig> = new_monitor_configs
+                                    .iter()
+                                    .map(|c| (c.id, c.clone()))
+                                    .collect();
+                                let new_uuids: HashSet<Uuid> = new_config_map.keys().copied().collect();
+
+                                // Collect helper-assigned UUIDs so their task handles
+                                // are NOT aborted during reload.  Helper-assigned monitors
+                                // live only in the owner's DB; aborting them here would
+                                // silently stop helper peers from checking private monitors.
+                                let helper_assigned_uuids: HashSet<Uuid> = self
+                                    .helper_assignments
+                                    .read()
+                                    .await
+                                    .keys()
+                                    .copied()
+                                    .collect();
+
+                                // Abort handles for monitors that no longer exist,
+                                // but keep handles for active helper assignments.
+                                self.task_handles.retain(|uuid, handle| {
+                                    if !new_uuids.contains(uuid) && !helper_assigned_uuids.contains(uuid) {
+                                        handle.abort();
+                                        false
+                                    } else {
+                                        true
+                                    }
+                                });
+
+                                // Schedule tasks for monitors not yet running
+                                let currently_running: HashSet<Uuid> =
+                                    self.task_handles.keys().copied().collect();
+                                for uuid in new_uuids.difference(&currently_running) {
+                                    if let Some(config) = new_config_map.get(uuid) {
+                                        let handle = scheduler.schedule_monitor(config.clone());
+                                        self.task_handles.insert(*uuid, handle);
+                                        info!("Scheduled new monitor: {}", uuid);
+                                    }
                                 }
-                                
-                                self.task_handles = scheduler.schedule_monitors(new_monitor_configs.clone());
-                                
-                                info!("Reloaded monitors: {} active", new_monitor_configs.len());
+
+                                info!("Monitors active: {}", self.task_handles.len());
                             }
                             Err(e) => {
                                 error!("Failed to reload monitors: {}", e);
@@ -830,8 +1396,66 @@ impl Orchestrator {
                             if let Err(e) = private_orch.run_maintenance().await {
                                 warn!("Helper maintenance failed: {}", e);
                             }
+                            // After maintenance, clear assignment tracking for monitors
+                            // that ended up with no helpers so the reload loop retries.
+                            let active = private_orch.get_assigned_monitor_uuids().await;
+                            assigned_private_monitors.retain(|uuid| active.contains(uuid));
                         }
                         last_helper_maintenance = Instant::now();
+                    }
+                }
+
+                // Periodic task: Re-dial bootstrap peers when peer count is low.
+                // Uses a startup backoff schedule (5 s → 10 s → 20 s) before settling
+                // at the normal 30 s interval so the first peer is found quickly.
+                _ = tokio::time::sleep_until(tokio::time::Instant::from_std(last_reconnect_attempt + current_reconnect_delay)) => {
+                    if last_reconnect_attempt.elapsed() >= current_reconnect_delay {
+                        // Re-dial when either we have very few connections OR we have
+                        // connections but none have announced as uppe-service peers.
+                        if p2p_network.is_enabled()
+                            && (connected_peers.len() < 2 || uppe_service_peers.is_empty())
+                        {
+                            debug!(
+                                "Peer count low ({}), re-dialing bootstrap peers (delay={}s)",
+                                connected_peers.len(),
+                                current_reconnect_delay.as_secs()
+                            );
+                            if let Err(e) = p2p_network.send_command(crate::p2p::messages::P2PCommand::DialBootstrapPeers).await {
+                                warn!("Failed to send DialBootstrapPeers: {}", e);
+                            }
+
+                            // If we still have no uppe-service peers, immediately retry
+                            // unhelped monitors — a peer that connected before it announced
+                            // itself may now be eligible.
+                            if uppe_service_peers.is_empty() {
+                                if let Some(private_orch) = &self.private_orchestrator {
+                                    if let Err(e) = private_orch.retry_unhelped_monitors().await {
+                                        tracing::debug!("startup retry_unhelped: {}", e);
+                                    }
+                                }
+                            }
+                        }
+
+                        // Advance through the startup schedule; stay at normal interval once exhausted.
+                        current_reconnect_delay = startup_reconnect_delays
+                            .pop_front()
+                            .unwrap_or(reconnect_interval);
+                        last_reconnect_attempt = Instant::now();
+                    }
+                }
+
+                // Periodic: re-broadcast our node announcement so peers that came
+                // online after our last connection-triggered announce can find us.
+                _ = tokio::time::sleep_until(tokio::time::Instant::from_std(
+                    last_periodic_announce + periodic_announce_interval
+                )) => {
+                    if last_periodic_announce.elapsed() >= periodic_announce_interval
+                        && p2p_network.is_enabled()
+                    {
+                        let _ = p2p_network.send_command(
+                            crate::p2p::messages::P2PCommand::AnnouncePresence
+                        ).await;
+                        last_periodic_announce = Instant::now();
                     }
                 }
 

--- a/apps/service/src/orchestrator/retention.rs
+++ b/apps/service/src/orchestrator/retention.rs
@@ -26,11 +26,7 @@ pub struct RetentionPolicy {
 
 impl Default for RetentionPolicy {
     fn default() -> Self {
-        Self {
-            private_result_days: 7,
-            public_result_days: 30,
-            peer_result_days: 30,
-        }
+        Self { private_result_days: 7, public_result_days: 30, peer_result_days: 30 }
     }
 }
 
@@ -67,10 +63,7 @@ impl RetentionCleanup {
 
         let peer_count = self.database.cleanup_expired_peer_results().await?;
 
-        info!(
-            "Retention cleanup completed: {} peer results deleted",
-            peer_count
-        );
+        info!("Retention cleanup completed: {} peer results deleted", peer_count);
 
         Ok(())
     }

--- a/apps/service/src/orchestrator/tests.rs
+++ b/apps/service/src/orchestrator/tests.rs
@@ -13,11 +13,11 @@ use crate::pool::{LibsqlManager, LibsqlPool};
 use anyhow::Result;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
-use tempfile::tempdir;
+use tempfile::{TempDir, tempdir};
 use uuid::Uuid;
 
 /// Helper to create test database pool
-async fn create_test_database() -> Result<(LibsqlPool, String)> {
+async fn create_test_database() -> Result<(TempDir, LibsqlPool, String)> {
     let temp_dir = tempdir()?;
     let db_path = temp_dir.path().join("test.db");
     let db_path_str = db_path.to_string_lossy().to_string();
@@ -32,7 +32,7 @@ async fn create_test_database() -> Result<(LibsqlPool, String)> {
     let conn: deadpool::managed::Object<LibsqlManager> = pool.get().await?;
     crate::database::initialize_database(&*conn).await?;
 
-    Ok((pool, db_path_str))
+    Ok((temp_dir, pool, db_path_str))
 }
 
 /// Helper to create test keypair
@@ -52,24 +52,19 @@ fn create_test_p2p_network(peer_id: String, public_key: [u8; 32]) -> Arc<P2PNetw
         .build();
 
     Arc::new(P2PNetwork::with_config(
-        peer_id,
-        false, // Disabled for unit tests
-        public_key,
-        config,
+        peer_id, false, // Disabled for unit tests
+        public_key, config,
     ))
 }
 
 #[tokio::test]
 async fn test_retention_policy_integration() -> Result<()> {
-    let (pool, _db_path) = create_test_database().await?;
+    let (_temp_dir, pool, _db_path) = create_test_database().await?;
     let database = Arc::new(DatabaseImpl::new_from_pool(pool));
 
     // Create custom retention policy: 1 second for all types
-    let policy = RetentionPolicy {
-        private_result_days: 0,
-        public_result_days: 0,
-        peer_result_days: 0,
-    };
+    let policy =
+        RetentionPolicy { private_result_days: 0, public_result_days: 0, peer_result_days: 0 };
 
     let cleanup = RetentionCleanup::new(database.clone(), policy);
 
@@ -82,7 +77,7 @@ async fn test_retention_policy_integration() -> Result<()> {
         latency_ms: Some(100),
         status_code: Some(200),
         error_message: None,
-        timestamp: SystemTime::now() - Duration::from_secs(7 * 24 * 3600 + 3600), // 7 days + 1 hour ago
+        timestamp: SystemTime::now() - Duration::from_secs(7 * 24 * 3600 + 3600), /* 7 days + 1 hour ago */
         verified: true,
         signature: vec![0u8; 64],
         created_at: SystemTime::now(),
@@ -108,7 +103,7 @@ async fn test_retention_policy_integration() -> Result<()> {
 
 #[tokio::test]
 async fn test_private_orchestrator_creation() -> Result<()> {
-    let (pool, _db_path) = create_test_database().await?;
+    let (_temp_dir, pool, _db_path) = create_test_database().await?;
     let database = Arc::new(DatabaseImpl::new_from_pool(pool));
     let keypair = create_test_keypair();
     let peer_id = keypair.public_key_hex();
@@ -116,12 +111,8 @@ async fn test_private_orchestrator_creation() -> Result<()> {
     let p2p_network = create_test_p2p_network(peer_id.clone(), keypair.public_key_bytes());
 
     // Create private orchestrator
-    let _orchestrator = PrivateMonitorOrchestrator::new(
-        database.clone(),
-        peer_id,
-        owner_pubkey,
-        p2p_network,
-    );
+    let _orchestrator =
+        PrivateMonitorOrchestrator::new(database.clone(), peer_id, owner_pubkey, p2p_network);
 
     // Verify creation succeeds (orchestrator should be functional)
     Ok(())
@@ -129,7 +120,7 @@ async fn test_private_orchestrator_creation() -> Result<()> {
 
 #[tokio::test]
 async fn test_owner_sync_with_empty_dht() -> Result<()> {
-    let (pool, _db_path) = create_test_database().await?;
+    let (_temp_dir, pool, _db_path) = create_test_database().await?;
     let database = Arc::new(DatabaseImpl::new_from_pool(pool));
     let keypair = create_test_keypair();
     let peer_id = keypair.public_key_hex();
@@ -137,12 +128,8 @@ async fn test_owner_sync_with_empty_dht() -> Result<()> {
     let owner_secret_key = keypair.x25519_secret_bytes();
     let p2p_network = create_test_p2p_network(peer_id.clone(), keypair.public_key_bytes());
 
-    let orchestrator = PrivateMonitorOrchestrator::new(
-        database.clone(),
-        peer_id,
-        owner_pubkey,
-        p2p_network,
-    );
+    let orchestrator =
+        PrivateMonitorOrchestrator::new(database.clone(), peer_id, owner_pubkey, p2p_network);
 
     // Sync with empty DHT should complete without error (no monitors, no assignments)
     // This tests the graceful handling of "no data" scenario
@@ -161,7 +148,7 @@ async fn test_owner_sync_with_empty_dht() -> Result<()> {
 
 #[tokio::test]
 async fn test_retention_cleanup_with_recent_results() -> Result<()> {
-    let (pool, _db_path) = create_test_database().await?;
+    let (_temp_dir, pool, _db_path) = create_test_database().await?;
     let database = Arc::new(DatabaseImpl::new_from_pool(pool));
 
     // Default policy: 7 days for private, 30 for public/peer
@@ -232,10 +219,8 @@ async fn test_encryption_roundtrip_integration() -> Result<()> {
     )?;
 
     // Decrypt using the owner's X25519 secret key — this is the critical roundtrip
-    let decrypted: CheckResult = decrypt_result_for_owner(
-        &encrypted,
-        &owner_keypair.x25519_secret_bytes(),
-    )?;
+    let decrypted: CheckResult =
+        decrypt_result_for_owner(&encrypted, &owner_keypair.x25519_secret_bytes())?;
 
     assert_eq!(decrypted.monitor_id, check_result.monitor_id);
     assert_eq!(decrypted.target, check_result.target);
@@ -249,7 +234,7 @@ async fn test_encryption_roundtrip_integration() -> Result<()> {
 
 #[tokio::test]
 async fn test_retention_periodic_cleanup_starts() -> Result<()> {
-    let (pool, _db_path) = create_test_database().await?;
+    let (_temp_dir, pool, _db_path) = create_test_database().await?;
     let database = Arc::new(DatabaseImpl::new_from_pool(pool));
 
     let policy = RetentionPolicy::default();
@@ -273,28 +258,24 @@ mod helper_assignment_tests {
 
     #[tokio::test]
     async fn test_helper_assignment_flow() -> Result<()> {
-        let (pool, _db_path) = create_test_database().await?;
+        let (_temp_dir, pool, _db_path) = create_test_database().await?;
         let database = Arc::new(DatabaseImpl::new_from_pool(pool));
         let keypair = create_test_keypair();
         let peer_id = keypair.public_key_hex();
         let owner_pubkey = keypair.x25519_public_key();
         let p2p_network = create_test_p2p_network(peer_id.clone(), keypair.public_key_bytes());
 
-        let _orchestrator = PrivateMonitorOrchestrator::new(
-            database.clone(),
-            peer_id,
-            owner_pubkey,
-            p2p_network,
-        );
+        let _orchestrator =
+            PrivateMonitorOrchestrator::new(database.clone(), peer_id, owner_pubkey, p2p_network);
 
         // Test helper assignment logic
         // Create a private monitor
-        let mut monitor = crate::database::models::Monitor::new_private(
+        let mut monitor = crate::database::models::Monitor::new(
             "Private Test".to_string(),
             "https://internal.example.com".to_string(),
             "https".to_string(),
-            keypair.public_key_hex(),
         );
+        monitor.owner_peer_id = Some(keypair.public_key_hex());
         monitor.enabled = true;
 
         let _monitor_id = database.save_monitor(&monitor).await?;


### PR DESCRIPTION
## Summary
- add a canonical signed audit event envelope to the Rust service
- persist signed audit events and attestation tables through a new schema migration
- add repository support for audit event reads/writes and fix Rust test harness drift uncovered by the change

## Verification
- `cargo test --manifest-path apps/service/Cargo.toml`

## Issue linkage
- Refs #37
- Partial #31
